### PR TITLE
Optimize macro judgment statement

### DIFF
--- a/examples/mqttclient_iot_explorer/mqttclient_iot_explorer.c
+++ b/examples/mqttclient_iot_explorer/mqttclient_iot_explorer.c
@@ -5,11 +5,14 @@
 #include "sal_module_wrapper.h"
 
 #define USE_ESP8266
+
 //#define USE_EC600S
 
-#if defined(USE_ESP8266)
+#ifdef USE_ESP8266
 #include "esp8266.h"
-#elif defined(USE_EC600S)
+#endif
+
+#ifdef USE_EC600S
 #include "ec600s.h"
 #endif
 
@@ -97,7 +100,6 @@ void mqttclient_task(void)
     esp8266_sal_init(esp8266_port);
     esp8266_join_ap("Mculover666", "mculover666");
 #endif
-
 
 #ifdef USE_EC600S
     ec600s_sal_init(HAL_UART_PORT_2);


### PR DESCRIPTION
因为在该文件中 ``USE_ESP8266`` 和 ``USE_EC600S`` 是互斥的，所以优化宏判断语句表述。