### PR TITLE
Rename time_init, time_update, timer_next_expires_get function with soft_ prefix

### DIFF
--- a/board/TencentOS_tiny_EVB_G0/KEIL/mqtt_iot_explorer_e53_light/demo/mqtt_iot_explorer_e53_light.c
+++ b/board/TencentOS_tiny_EVB_G0/KEIL/mqtt_iot_explorer_e53_light/demo/mqtt_iot_explorer_e53_light.c
@@ -305,9 +305,6 @@ void application_entry(void *arg)
 {
     char *str = "TencentOS-tiny";
 
-    // 初始化tencent-os tiny定时器模块
-    timer_init();
-	
     // 初始化按键检测模块
     stm32g0xx_key_init();
 	

--- a/kernel/core/include/tos_timer.h
+++ b/kernel/core/include/tos_timer.h
@@ -177,13 +177,13 @@ __API__ k_err_t tos_timer_period_change(k_timer_t *tmr, k_tick_t period);
  *
  * @return  None
  */
-__KNL__ void timer_update(void);
+__KNL__ void soft_timer_update(void);
 
 #endif
 
-__KNL__ k_err_t timer_init(void);
+__KNL__ k_err_t soft_timer_init(void);
 
-__KNL__ k_tick_t timer_next_expires_get(void);
+__KNL__ k_tick_t soft_timer_next_expires_get(void);
 
 #endif
 

--- a/kernel/core/tos_sys.c
+++ b/kernel/core/tos_sys.c
@@ -42,7 +42,7 @@ __API__ k_err_t tos_knl_init(void)
     }
 
 #if TOS_CFG_TIMER_EN > 0
-    err = timer_init();
+    err = soft_timer_init();
     if (err != K_ERR_NONE) {
         return err;
     }
@@ -187,7 +187,7 @@ __KNL__ k_tick_t knl_next_expires_get(void)
     tick_next_expires = tick_next_expires_get();
 
 #if TOS_CFG_TIMER_EN > 0u
-    timer_next_expires = timer_next_expires_get();
+    timer_next_expires = soft_timer_next_expires_get();
 #endif
 
 #if TOS_CFG_TIMER_EN > 0u

--- a/kernel/core/tos_tick.c
+++ b/kernel/core/tos_tick.c
@@ -139,7 +139,7 @@ __API__ void tos_tick_handler(void)
     tick_update((k_tick_t)1u);
 
 #if TOS_CFG_TIMER_EN > 0u && TOS_CFG_TIMER_AS_PROC > 0u
-    timer_update();
+    soft_timer_update();
 #endif
 
 #if TOS_CFG_ROUND_ROBIN_EN > 0u

--- a/kernel/core/tos_timer.c
+++ b/kernel/core/tos_timer.c
@@ -253,7 +253,7 @@ __API__ k_err_t tos_timer_period_change(k_timer_t *tmr, k_tick_t period)
     return timer_change(tmr, period, TIMER_CHANGE_TYPE_PERIOD);
 }
 
-__KNL__ k_tick_t timer_next_expires_get(void)
+__KNL__ k_tick_t soft_timer_next_expires_get(void)
 {
     TOS_CPU_CPSR_ALLOC();
     k_tick_t next_expires;
@@ -274,7 +274,7 @@ __KNL__ k_tick_t timer_next_expires_get(void)
 
 #if TOS_CFG_TIMER_AS_PROC > 0u
 
-__KNL__ void timer_update(void)
+__KNL__ void soft_timer_update(void)
 {
     k_timer_t *tmr, *tmp;
 
@@ -314,7 +314,7 @@ __STATIC__ void timer_task_entry(void *arg)
 
     arg = arg; // make compiler happy
     while (K_TRUE) {
-        next_expires = timer_next_expires_get();
+        next_expires = soft_timer_next_expires_get();
         if (next_expires == TOS_TIME_FOREVER) {
             tos_task_suspend(K_NULL);
         } else if (next_expires > (k_tick_t)0u) {
@@ -347,13 +347,13 @@ __STATIC__ void timer_task_entry(void *arg)
 
 #endif
 
-__KNL__ k_err_t timer_init(void)
+__KNL__ k_err_t soft_timer_init(void)
 {
 #if TOS_CFG_TIMER_AS_PROC > 0u
     return K_ERR_NONE;
 #else
     return tos_task_create(&k_timer_task,
-            "timer",
+            "soft_timer",
             timer_task_entry,
             K_NULL,
             k_timer_task_prio,

--- a/kernel/pm/tos_tickless.c
+++ b/kernel/pm/tos_tickless.c
@@ -111,7 +111,7 @@ __STATIC__ void tickless_tick_fix(k_tick_t tick_sleep)
     tick_update(tick_sleep);
 
 #if TOS_CFG_TIMER_EN > 0u && TOS_CFG_TIMER_AS_PROC > 0u
-    timer_update();
+    soft_timer_update();
 #endif
 
     tickless_tick_resume();


### PR DESCRIPTION
time_init 函数命名 和 gd 的部分库的函数声明存在冲突：
![2022-04-13_16-25.png](https://static.aichat.net/chat/202204/f046b096-1604-4893-87a3-0630d2215793.png)
同时发现，time_update 和 timer_next_expires_get 也没有 tos_ 前缀，重命名这三个函数添加 tos_ 前缀保持统一。