### PR TITLE
统一 SW_Handler 命名为wch官方sdk标准

### DIFF
--- a/arch/risc-v/risc-v3a/rv32i/gcc/port_s.S
+++ b/arch/risc-v/risc-v3a/rv32i/gcc/port_s.S
@@ -143,8 +143,8 @@ restore_context:
 
 /* just switch at Software interrupt */
 .align 2
-.global SW_handler
-SW_handler:
+.global SW_Handler
+SW_Handler:
 #if ARCH_RISCV_FPU
 	addi sp, sp, -128
 	fsw  f0,  __reg_f0_OFFSET(sp)

--- a/board/TencentOS_Tiny_CH32V307_EVB/Startup/startup_ch32v30x.S
+++ b/board/TencentOS_Tiny_CH32V307_EVB/Startup/startup_ch32v30x.S
@@ -42,7 +42,7 @@ _vector_base:
     .word   0
     .word   SysTick_Handler            /* SysTick */
     .word   0
-    .word   SW_handler                 /* SW */
+    .word   SW_Handler                 /* SW */
     .word   0
     /* External Interrupts */
     .word   WWDG_IRQHandler            /* Window Watchdog */
@@ -143,7 +143,7 @@ _vector_base:
     .weak   Ecall_U_Mode_Handler       /* Ecall U Mode */
     .weak   Break_Point_Handler        /* Break Point */
     .weak   SysTick_Handler            /* SysTick */
-    .weak   SW_handler                 /* SW */
+    .weak   SW_Handler                 /* SW */
     .weak   WWDG_IRQHandler            /* Window Watchdog */
     .weak   PVD_IRQHandler             /* PVD through EXTI Line detect */
     .weak   TAMPER_IRQHandler          /* TAMPER */
@@ -239,7 +239,7 @@ Ecall_M_Mode_Handler:  1:  j 1b
 Ecall_U_Mode_Handler:  1:  j 1b
 Break_Point_Handler:  1:  j 1b
 SysTick_Handler:  1:  j 1b
-SW_handler:  1:  j 1b
+SW_Handler:  1:  j 1b
 WWDG_IRQHandler:  1:  j 1b
 PVD_IRQHandler:  1:  j 1b
 TAMPER_IRQHandler:  1:  j 1b


### PR DESCRIPTION
arch/risc-v/risc-v3a/rv32i/gcc/port_s.S
board/TencentOS_Tiny_CH32V307_EVB/Startup/startup_ch32v30x.S

以上文件内的SW_handler，与上下文的其他符号命名风格不一致。假如客户自行更新ch32v307的SDK源文件进行替换，编译不会报错，但是因为命名不一致，系统无法正常运行。