### PR TITLE
Fixed an array out-of-bounds issue caused by bubbling sort writing error

### DIFF
--- a/board/TencentOS_Tiny_CH32V307_EVB/Peripheral/src/ch32v30x_adc.c
+++ b/board/TencentOS_Tiny_CH32V307_EVB/Peripheral/src/ch32v30x_adc.c
@@ -1071,8 +1071,8 @@ int16_t Get_CalibrationValue(ADC_TypeDef* ADCx)
         buf[i] = ADCx->RDATAR;
     }
 
-    for(i=0; i<10; i++){
-        for(j=0; j<10; j++){
+    for(i=0; i<9; i++){
+        for(j=0; j<9-i; j++){
             if(buf[j]>buf[j+1]){
               t=buf[j];
               buf[j]=buf[j+1];


### PR DESCRIPTION
在原本的代码中，当循环至j=9时，将访问到buf[10]，但是在1063行对buf的定义：uint16_t buf[10];中得知访问buf[10]是一个数组越界访问行为，严重的话将会导致栈溢出漏洞。
而产生这个问题的原因在于，原本的冒泡排序的边界条件书写错误，将原本的错误条件：
```
for(i=0; i<10; i++){
    for(j=0; j<10; j++){
        // the code to swap
    }
}
```
更正为正确条件：
```
for(i=0; i<9; i++){
    for(j=0; j<9-i; j++){
        // the code to swap
    }
}
```
从而解决了这个问题