### PR TITLE
[HUST-CSE]Add null pointer check in OSA_TaskSetPriority

### DIFF
--- a/platform/vendor_bsp/nxp/MIMXRT1052/components/osa/fsl_os_abstraction_bm.c
+++ b/platform/vendor_bsp/nxp/MIMXRT1052/components/osa/fsl_os_abstraction_bm.c
@@ -312,7 +312,7 @@ osa_status_t OSA_TaskSetPriority(osa_task_handle_t taskHandle, osa_task_priority
         }
         list_element = LIST_GetNext(list_element);
     }
-    if (ptaskStruct->priority > tcb->priority)
+    if ((NULL == tcb) || (ptaskStruct->priority > tcb->priority))
     {
         OSA_InterruptDisable();
         (void)LIST_AddTail(&s_osaState.taskList, (list_element_handle_t)(void *)&(ptaskStruct->link));


### PR DESCRIPTION
#### 1.这个PR修复的是什么问题？
源码  ： `if (ptaskStruct->priority > tcb->priority)`
这段代码在while循环未进入时，tcb易产生空指针问题
此处给出文件路径：
platform/vendor_bsp/nxp/MIMXRT1052/components/osa/fsl_os_abstraction_bm.c
#### 2.这个PR不修复具体会带来什么后果？
tcb->priority无效，并会导致指针错误、程序崩溃
#### 3.PR修复方案的依据是什么？
在原判断条件的基础上，添加对于空指针的检验，保证了代码的安全性：
`if ((NULL == tcb) || (ptaskStruct->priority > tcb->priority))`
#### 4. 在什么环境下测试或者验证过？
all
