### PR TITLE
[HUST CSE]Modify incorrect expressions passed into the assert function

### DIFF
--- a/platform/vendor_bsp/nxp/LPC824/drivers/fsl_swm.c
+++ b/platform/vendor_bsp/nxp/LPC824/drivers/fsl_swm.c
@@ -95,7 +95,7 @@ void SWM_SetFixedPinSelect(SWM_Type *base, swm_select_fixed_pin_t func, bool ena
 {
     /* Check arguments */
     assert(NULL != base);
-    assert((func > 0) || func < kSWM_FIXEDPIN_NUM_FUNCS);
+    assert((func > 0) && func < kSWM_FIXEDPIN_NUM_FUNCS);
 
     if (enable)
     {


### PR DESCRIPTION
在原本的代码中，kSWM_FIXEDPIN_NUM_FUNCS在fsl_swm_connections.h中定义的值为
`kSWM_FIXEDPIN_NUM_FUNCS = 0x80000041`
导致assert函数无法检验条件正确性并终止程序执行。
原代码为：
`assert((func > 0) || func < kSWM_FIXEDPIN_NUM_FUNCS);`
结合函数使用语境，将'||'修改为'&&'，修改后代码如下：
`assert((func > 0) && func < kSWM_FIXEDPIN_NUM_FUNCS);`
从而解决了这个问题。