### PR TITLE
Fixed a wrong parament name in printf

### DIFF
--- a/examples/bin_file_download_through_module/bin_file_download_through_module.c
+++ b/examples/bin_file_download_through_module/bin_file_download_through_module.c
@@ -148,7 +148,7 @@ static int ota_http_body_read(int fd, int file_len, unsigned char *buf, size_t b
     
 #define MIN(a, b)       ((a) < (b) ? (a) : (b))
     
-    printf("file_len is %d,  remain_len = %d\r\n", file_len, read_len);
+    printf("file_len is %d,  remain_len = %d\r\n", file_len, remain_len);
     
     while (remain_len > 0) {
         read_len = MIN(remain_len, buf_len);


### PR DESCRIPTION
**1. 这个PR修复的是什么问题？**
根据前后文以及printf的信息，这里的`printf("file_len is %d,  remain_len = %d\r\n", file_len, read_len);`应该改为`printf("file_len is %d,  remain_len = %d\r\n", file_len, remain_len);`

**2. 这个PR不修复具体会带来什么后果？**
错误的输出，且`read_len`未初始化，可能导致不确定行为

**3. PR修复方案的依据是什么？**
前后文信息以及printf的输出提示信息

**4. 在什么环境下测试或者验证过？**
all