### PR TITLE
[HUST CSE] Fix: 字符数组str越界

### DIFF
--- a/board/TencentOS_tiny_EVB_G0/KEIL/mqtt_iot_explorer_tc_pm25/demo/mqtt_iot_explorer_tc_pm25_oled.c
+++ b/board/TencentOS_tiny_EVB_G0/KEIL/mqtt_iot_explorer_tc_pm25/demo/mqtt_iot_explorer_tc_pm25_oled.c
@@ -82,7 +82,7 @@ void mqtt_demo_task(void)
     
     device_info_t dev_info;
     memset(&dev_info, 0, sizeof(device_info_t));
-    char str[16];   
+    char str[30];   
     size_t mail_size;
     uint8_t report_error_count = 0;
     char client_token[10];


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
在board/TencentOS_tiny_EVB_G0/KEIL/mqtt_iot_explorer_tc_pm25/demo/mqtt_iot_explorer_tc_pm25_oled.c这个文件中，第85行创建的字符数组str大小只有16，后续后续101和103行sprintf的字符串明显超出了16的大小，会发生数组越界，出现问题

#### 你的解决方案是什么 (what is your solution)
将str字符数组开大空间，统计了一下最长是26，因此开辟30的空间

#### 在什么测试环境下测试通过 (what is the test environment)
只增加了str的空间，因此测试一定会通过

]