### PR TITLE
Fix: 字符数组expect_str越界

### DIFF
--- a/devices/air724/air724.c
+++ b/devices/air724/air724.c
@@ -386,7 +386,7 @@ static int air724_recv(int id, void *buf, size_t len)
 int air724_send(int id, const void *buf, size_t len)
 {
     at_echo_t echo;
-    char expect_str[10];
+    char expect_str[30];
 
     if (tos_at_global_lock_pend() != 0) {
         return -1;

--- a/devices/air724/air724.c
+++ b/devices/air724/air724.c
@@ -386,7 +386,7 @@ static int air724_recv(int id, void *buf, size_t len)
 int air724_send(int id, const void *buf, size_t len)
 {
     at_echo_t echo;
-    char expect_str[30];
+    char expect_str[24];
 
     if (tos_at_global_lock_pend() != 0) {
         return -1;


### PR DESCRIPTION
[

### 为什么提交这份PR (why to submit this PR)
在OpenAtomFoundation/TencentOS-tiny/devices/air724/air724.c这个文件中，第389行创建的字符数组expect_str大小只有10，后续412行sprintf的字符串明显超出了10的大小，会发生数组越界，出现问题

### 你的解决方案是什么 (what is your solution)
将expect_str字符数组开大空间, 考虑到使用%d时未指定位数，因此开辟24的空间来保证一定不会越界，且考虑数据对齐

### 在什么测试环境下测试通过 (what is the test environment)
all

]