### PR TITLE
[HUST CSE]Modify the null pointer fifo to access first and then judge

### DIFF
--- a/components/connectivity/mqttclient/common/log/fifo.c
+++ b/components/connectivity/mqttclient/common/log/fifo.c
@@ -98,10 +98,10 @@ unsigned int salof_fifo_read(salof_fifo_t fifo, void *buff, unsigned int len, un
 {
     int l;
 
-    salof_sem_pend(fifo->sem, timeout);
-
     if((!fifo) || (!buff) || (!len))
         return 0;
+        
+    salof_sem_pend(fifo->sem, timeout);
     
     len = FIFO_MIN(len, fifo->in - fifo->out);
 


### PR DESCRIPTION
1.为什么提交这份PR (why to submit this PR)
在/components/connectivity/mqttclient/common/log/fifo.c这个文件中，第101行

    salof_sem_pend(fifo->sem, timeout);

    if((!fifo) || (!buff) || (!len))
        return 0;
这处代码首先进行salof_sem_pend(fifo->sem, timeout)再进行判断fifo是否为空有问题，如果fifo为空，则访问其成员变量会导致未定义的行为。

2.你的解决方案是什么 (what is your solution)
应该先检查传入的salof_fifo_t类型的参数fifo是否为空（即是否为NULL），然后才能使用它的成员变量。因此，应该将if((!fifo) || (!buff) || (!len))这个语句的判断移到salof_sem_pend(fifo->sem, timeout)之前。

3.在什么测试环境下测试通过 (what is the test environment)
all
