### PR TITLE
[HUST CSE]Modify invalid links

### DIFF
--- a/doc/23.CMSIS_RTOS_API_Use_Guide.md
+++ b/doc/23.CMSIS_RTOS_API_Use_Guide.md
@@ -12,7 +12,7 @@ CMSIS-RTOS是用于实时操作系统（RTOS）的一层通用API，它提供了
 
 CMSIS-RTOS API的整体架构如下图：
 ![](./image/CMSIS_RTOS_API_User_Guide/cmsis-rtos-api.png)
-CMSIS-RTOS API官方参考文档链接：[https://www.keil.com/pack/doc/CMSIS/RTOS/html/index.html](https://www.keil.com/pack/doc/CMSIS/RTOS/html/index.html/)
+CMSIS-RTOS API官方参考文档链接：[https://www.keil.com/pack/doc/CMSIS/RTOS/html/index.html](https://www.keil.com/pack/doc/CMSIS/RTOS/html/index.html)
 
 # 2. CMSIS-RTOS API列表
 下面列出了 CMSIS-RTOS API <font color="red">v1.02</font> 版本提供的所有API。

--- a/examples/tos_meets_rust/docs/rust.md
+++ b/examples/tos_meets_rust/docs/rust.md
@@ -190,6 +190,6 @@
 
 # 参考
 
-- [Hosting Embedded Rust apps on Apache Mynewt with STM32 Blue Pill](https://medium.com/@ly.lee/hosting-embedded-rust-apps-on-apache-mynewt-with-stm32-blue-pill-c86b119fe5f)
+- [Hosting Embedded Rust apps on Apache Mynewt with STM32 Blue Pill](https://lupyuen.github.io/articles/hosting-embedded-rust-apps-on-apache-mynewt-with-stm32-blue-pill)
 - [STM32L0 Rust Part 1 - Getting Started](https://craigjb.com/2019/12/31/stm32l0-rust/)
 - [FreeRTOS meets Rust](http://www.hashmismatch.net/freertos-meets-rust/)


### PR DESCRIPTION
1. 在文件_TencentOS-tiny\doc\23.CMSIS_RTOS_API_Use_Guide.md_中，此处末尾的html后多了”/“，删去
原代码：
```
  CMSIS-RTOS API官方参考文档链接：[https://www.keil.com/pack/doc/CMSIS/RTOS/html/index.html](https://www.keil.com/pack/doc/CMSIS/RTOS/html/index.html/)
```
2. 文件_TencentOS-tiny\examples\tos_meets_rust\docs\rust.md_末尾参考链接失效
原代码为：
```
 - [Hosting Embedded Rust apps on Apache Mynewt with STM32 Blue Pill](https://medium.com/@ly.lee/hosting-embedded-rust-apps-on-apache-mynewt-with-stm32-blue-pill-c86b119fe5f)
```
修改：
```
 - [Hosting Embedded Rust apps on Apache Mynewt with STM32 Blue Pill](https://lupyuen.github.io/articles/hosting-embedded-rust-apps-on-apache-mynewt-with-stm32-blue-pill)
```
