### PR TITLE
Fix pointer addition with NULL pointer

### DIFF
--- a/components/utils/Bcrypt/src/wrapper.c
+++ b/components/utils/Bcrypt/src/wrapper.c
@@ -389,8 +389,8 @@ static void *run(void *arg)
 			continue;
 
 		if (strcmp(crypt_ra(key, hash, &data, &size), hash)) {
-			printf("%d: FAILED (crypt_ra/%d/%lu)\n",
-				(int)((char *)arg - (char *)0), i, count);
+			printf("%d: FAILED (crypt_ra/%d/%lu)\n", 
+			       (int)(intptr_t)arg, i, count);
 			free(data);
 			return NULL;
 		}
@@ -398,7 +398,7 @@ static void *run(void *arg)
 	} while (running);
 
 	free(data);
-	return count + (char *)0;
+	return (void *)(intptr_t)count;
 }
 
 int main(void)


### PR DESCRIPTION
[

为什么提交这份PR (why to submit this PR)

在第393行和第401行代码中，将 NULL 指针（(char *)0）与另一个指针或整数相加。当与空指针进行算术操作时，结果是未定义的。
你的解决方案是什么 (what is your solution)
将 arg 与 (char *)0 指针相减，可以改为直接将 arg 强制转换为 int 类型。同样，将 count 与 (char *)0 相加也可以改为将 count 强制转换为 void * 类型。这里使用了 intptr_t 类型，它是一个整数类型，可以保证在转换为指针类型时不会丢失数据。

在什么测试环境下测试通过 (what is the test environment)
all

]