### PR TITLE
[HUST CSE] Add a useless return value for _thread_entry to avoid compilation error.

### DIFF
--- a/arch/linux/posix/gcc/port.c
+++ b/arch/linux/posix/gcc/port.c
@@ -291,6 +291,7 @@ __PORT__ void *_thread_entry(void *arg)
     _wait_resume();
     params->entry(params->arg);
     params->exit(params->arg);
+    return NULL;
 }
 
 __PORT__ void _handle_context_switch()


### PR DESCRIPTION
The file /arch/linux/posix/gcc/port.c has a function _thread_entry, which has no return value but defined as void*(void), to avoid compilation error, a 'return NULL' was added into the end of this function.