### PR TITLE
[bsp][BearPi_STM32L431RC] update usart.c(remove tos_at.h)

### DIFF
--- a/board/BearPi_STM32L431RC/BSP/Src/usart.c
+++ b/board/BearPi_STM32L431RC/BSP/Src/usart.c
@@ -19,7 +19,6 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "usart.h"
-#include "tos_at.h"
 
 /* USER CODE BEGIN 0 */
 uint8_t data;


### PR DESCRIPTION
将usart.c中tos_at.h头文件删除，at框架应该是可裁剪的，不应该直接在基础驱动中包含该头文件，或者应该使用宏来管理是否包含该头文件