### PR TITLE
Fix formatting issues

### DIFF
--- a/tools/STM32CubeMX_pack/Documentation/README.md
+++ b/tools/STM32CubeMX_pack/Documentation/README.md
@@ -1,6 +1,6 @@
 ![](media/7cdcedffbe9a424e13fbb8b9d86c710d.png)
 
-# 基于STM32Cube MX开发的TencentOS-Tiny软件包
+# 基于 STM32Cube MX 开发的 TencentOS-Tiny 软件包
 
 TencentOS-Tiny software package based on STM32Cube MX
 
@@ -20,19 +20,19 @@ Email：1797878653@qq.com
 
 腾讯物联网操作系统（TencentOS
 tiny）是腾讯面向物联网领域开发的实时操作系统，具有低功耗，低资源占用，模块化，可裁剪等特性。TencentOS
-tiny提供了最精简的 RTOS 内核，内核组件可裁剪可配置，可灵活移植到多种终端
-MCU上；基于RTOS内核提供了COAP/MQTT/TLS/DTLS等常用物联网协议栈及组件，方便用户快速接入腾讯云物联网通信IoT
+tiny 提供了最精简的 RTOS 内核，内核组件可裁剪可配置，可灵活移植到多种终端
+MCU 上；基于 RTOS 内核提供了 COAP/MQTT/TLS/DTLS 等常用物联网协议栈及组件，方便用户快速接入腾讯云物联网通信 IoT
 Hub；同时，为物联网终端厂家提供一站式软件解决方案，方便各种物联网设备快速接入腾讯云，可支撑智慧城市、智能穿戴、车联网等多种行业应用。
 
-为了减少开发人员移植TencentOS
-tiny到STM32系列单片机上的开发时间，研究了**STM32Cube MX软件包的制作**，基于STM32
-PackCreator完成了TencentOS Tiny软件包的封装，并在STM32Cube IDE和MDK-ARM
-v5上完成了软件包的**移植测试**，从而用户在安装本软件包后，能够使用pack**在STM32Cube
-MX上直**接生成适合不同MCU的TencentOS Tiny工程。
+为了减少开发人员移植 TencentOS
+tiny 到 STM32 系列单片机上的开发时间，研究了**STM32Cube MX 软件包的制作**，基于 STM32
+PackCreator 完成了 TencentOS Tiny 软件包的封装，并在 STM32Cube IDE 和 MDK-ARM
+v5 上完成了软件包的**移植测试**，从而用户在安装本软件包后，能够使用 pack**在 STM32Cube
+MX 上直**接生成适合不同 MCU 的 TencentOS Tiny 工程。
 
 目录
 
-[1、STM32 Cube MX软件包介绍](#1stm32-cube-mx软件包介绍)
+[1、STM32 Cube MX 软件包介绍](#1stm32-cube-mx软件包介绍)
 
 [1.1 软件包简介](#11-软件包简介)
 
@@ -40,11 +40,11 @@ MX上直**接生成适合不同MCU的TencentOS Tiny工程。
 
 [1.2.1 软件包开发过程](#121-软件包开发过程)
 
-[1.2.2 PDSC文件的编写](#122-利用stm32packcreator制作软件包)
+[1.2.2 PDSC 文件的编写](#122-利用stm32packcreator制作软件包)
 
 [1.2.3 生成软件包](#_Toc82013881)
 
-[2、TencentOS-tiny软件包](#2tencentos-tiny软件包)
+[2、TencentOS-tiny 软件包](#2tencentos-tiny软件包)
 
 [2.1 软件包内容](#21-软件包内容)
 
@@ -52,10 +52,10 @@ MX上直**接生成适合不同MCU的TencentOS Tiny工程。
 
 [3、软件包测试](#3软件包测试)
 
-[3.1 ARM内核移植TencentOS
-tiny软件包](#31-stm32-mcu移植测试生成stm32-cubeide工程)
+[3.1 ARM 内核移植 TencentOS
+tiny 软件包](#31-stm32-mcu移植测试生成stm32-cubeide工程)
 
-[3.2 STM32不依赖裸机工程移植](#32-stm32-board移植测试生成mdk-arm-v5工程)
+[3.2 STM32 不依赖裸机工程移植](#32-stm32-board移植测试生成mdk-arm-v5工程)
 
 [3.3 单片机裸机工程移植](#33-单片机测试)
 
@@ -65,38 +65,38 @@ tiny软件包](#31-stm32-mcu移植测试生成stm32-cubeide工程)
 
 [6、附录-移植配置参考](#_Toc82013891)
 
-[6.1 MDK5.14版本移植到ARM内核](#_Toc82013892)
+[6.1 MDK5.14 版本移植到 ARM 内核](#_Toc82013892)
 
-[6.1.1 Cortex-M0内核移植](#_Toc82013893)
+[6.1.1 Cortex-M0 内核移植](#_Toc82013893)
 
 [6.1.2 Cortex-M0+内核移植](#_Toc82013894)
 
-[6.1.3 Cortex-M3内核移植](#_Toc82013895)
+[6.1.3 Cortex-M3 内核移植](#_Toc82013895)
 
-[6.1.4 Cortex-M4内核移植](#_Toc82013896)
+[6.1.4 Cortex-M4 内核移植](#_Toc82013896)
 
-[6.1.5 Cortex-M7内核移植](#_Toc82013897)
+[6.1.5 Cortex-M7 内核移植](#_Toc82013897)
 
-[6.2 MDK5.14版本移植到基于ARM内核的芯片](#_Toc82013898)
+[6.2 MDK5.14 版本移植到基于 ARM 内核的芯片](#_Toc82013898)
 
-[6.2.1 移植到stm32f103c8芯片](#_Toc82013899)
+[6.2.1 移植到 stm32f103c8 芯片](#_Toc82013899)
 
-[6.2.2 移植到stm32f767igt芯片](#_Toc82013900)
+[6.2.2 移植到 stm32f767igt 芯片](#_Toc82013900)
 
 [6.3
-MDK5.30和MDK5.35版本移植（Cortex-M0+、0、3、4、7内核和芯片）](#_Toc82013901)
+MDK5.30 和 MDK5.35 版本移植（Cortex-M0+、0、3、4、7 内核和芯片）](#_Toc82013901)
 
-[6.4 MDK5.30和MDK5.35版本移植（Cortex-M23、33）](#_Toc82013902)
+[6.4 MDK5.30 和 MDK5.35 版本移植（Cortex-M23、33）](#_Toc82013902)
 
-[6.4.1 Cortex-M23内核移植](#_Toc82013903)
+[6.4.1 Cortex-M23 内核移植](#_Toc82013903)
 
-[6.4.2 Cortex-M33内核移植](#_Toc82013904)
+[6.4.2 Cortex-M33 内核移植](#_Toc82013904)
 
-# 1、STM32 Cube MX软件包介绍
+# 1、STM32 Cube MX 软件包介绍
 
 ## 1.1 软件包简介
 
-在进行嵌入式软件开发时，ARM为我们提供了软件包功能，能够将软件算法等模块进行集成封装，从而方便第三方用户使用。ARM软件包能够为微控制器设备和开发板提供支持，包含软件组件（Software
+在进行嵌入式软件开发时，ARM 为我们提供了软件包功能，能够将软件算法等模块进行集成封装，从而方便第三方用户使用。ARM 软件包能够为微控制器设备和开发板提供支持，包含软件组件（Software
 Component）如驱动程序和中间件，还可以包含示例项目和代码模板等，主要有以下类型的软件包：
 
 (1) 器件系列包（Device Family
@@ -105,7 +105,7 @@ Pack）：由硅供应商或工具供应商生成，为特定的目标微控制�
 (2) 板级支持包（Board Support
 Pack）：由电路板供应商发布，为安装在电路板上的外围硬件提供软件支持。
 
-(3) CMSIS软件包：由ARM提供，包括对CMSIS核心、DSP和RTOS的支持；
+(3) CMSIS 软件包：由 ARM 提供，包括对 CMSIS 核心、DSP 和 RTOS 的支持；
 
 (4) 中间件包（Middleware
 Pack）：由芯片供应商、工具供应商或第三方创建；通过提供对常用软件组件（如软件堆栈、特殊硬件库等）的软件集成，从而减少开发时间；
@@ -120,177 +120,177 @@ Pack）：由芯片供应商、工具供应商或第三方创建；通过提供�
 
 (3) 代码模板，方便使用软件组件。
 
-一个完整的软件包是一个ZIP文件，包含所有需要的软件库和文件，以及一个包含软件包所有信息的包描述文件（PDSC文件），ARM软件包的结构是在CMSIS中定义的(<http://www.keil.com/CMSIS/Pack>)。
+一个完整的软件包是一个 ZIP 文件，包含所有需要的软件库和文件，以及一个包含软件包所有信息的包描述文件（PDSC 文件），ARM 软件包的结构是在 CMSIS 中定义的(<http://www.keil.com/CMSIS/Pack>)。
 
 STM32
-CubeMX是ST公司推出了专门用于生成STM32的HAL代码的代码生成软件，可以通过可视化界面完成工程的配置，同时生成能够在STM32
-CubeMX、Keil等软件中运行的工程。STM32 Cube
-MX软件包是在ARM软件包的基础上，结合ST公司提供的软件包生成工具STM32
-PackCreator制作的，利用这个软件我们可以很方便地以图形化界面的方式进行软件包的制作。
+CubeMX 是 ST 公司推出了专门用于生成 STM32 的 HAL 代码的代码生成软件，可以通过可视化界面完成工程的配置，同时生成能够在 STM32
+CubeMX、Keil 等软件中运行的工程。STM32 Cube
+MX 软件包是在 ARM 软件包的基础上，结合 ST 公司提供的软件包生成工具 STM32
+PackCreator 制作的，利用这个软件我们可以很方便地以图形化界面的方式进行软件包的制作。
 
-如下图所示，使用STM32PackCreator需要我们的操作系统安装Java™ Runtime Environment
-(JRE)和JavaFX™，目前STM32CubeMX已经更新到了6.3版本，但这个版本并没有集成JavaFX，最为方便的方式是安装STM32
-CubeMX 6.2版本，省去了JavaFX的配置问题。
+如下图所示，使用 STM32PackCreator 需要我们的操作系统安装 Java™ Runtime Environment
+(JRE)和 JavaFX™，目前 STM32CubeMX 已经更新到了 6.3 版本，但这个版本并没有集成 JavaFX，最为方便的方式是安装 STM32
+CubeMX 6.2 版本，省去了 JavaFX 的配置问题。
 
-![在这里插入图片描述](media/e7f22ab88c1c1a558d17287582631d83.png)
+![](media/e7f22ab88c1c1a558d17287582631d83.png)
 
-图1.1 STM32PackCreator使用要求
+图 1.1 STM32PackCreator 使用要求
 
 具体步骤如下：
 
-（1）安装STM32CubeMX6.2.0：[STM32CubeMX - STM32Cube初始化代码生成器 -
+（1）安装 STM32CubeMX6.2.0：[STM32CubeMX - STM32Cube 初始化代码生成器 -
 STMicroelectronics](https://www.st.com/zh/development-tools/stm32cubemx.html#get-software)；
 
-![在这里插入图片描述](media/bece761bd6b5e020a7eb2f315023f5d2.png)
+![](media/bece761bd6b5e020a7eb2f315023f5d2.png)
 
-图1.2 下载STM32CubeMX6.2.0
+图 1.2 下载 STM32CubeMX6.2.0
 
-（2）双击安装目录下的STM32PackCreator，此时会提示需要安装JRE，点击确定，跳转到[https://java.com/zh-CN/download/](https://aijishu.com/link?target=https%3A%2F%2Fjava.com%2Fzh-CN%2Fdownload%2F)，然后下载安装。
+（2）双击安装目录下的 STM32PackCreator，此时会提示需要安装 JRE，点击确定，跳转到[https://java.com/zh-CN/download/](https://aijishu.com/link?target=https%3A%2F%2Fjava.com%2Fzh-CN%2Fdownload%2F)，然后下载安装。
 
-![在这里插入图片描述](media/95511cb01e058ea0e8b39f299f69b5e3.png)
+![](media/95511cb01e058ea0e8b39f299f69b5e3.png)
 
-![在这里插入图片描述](media/fd5ec491a0fe52b056f0c5e0f1a862b7.png)
+![](media/fd5ec491a0fe52b056f0c5e0f1a862b7.png)
 
-![在这里插入图片描述](media/18bd45f297b4028820de6851bd922274.png)
+![](media/18bd45f297b4028820de6851bd922274.png)
 
-图1.3 STM32PackCreator使用前的配置
+图 1.3 STM32PackCreator 使用前的配置
 
-（3）然后再次双击打开STM32PackCreator.exe，STM32 PackCreator的界面如下图所示。
+（3）然后再次双击打开 STM32PackCreator.exe，STM32 PackCreator 的界面如下图所示。
 
 ![](media/bbc029d5204e1f954af5c3adb0717d00.png)
 
-图1.4 STM32 PackCreator界面
+图 1.4 STM32 PackCreator 界面
 
 ## 1.2 软件包开发
 
 ### 1.2.1 软件包开发过程
 
-软件包的开发过程相当于完成了一项产品的制作，因此引入产品生命周期管理（PLM）的概念，PLM包括以下四个阶段：（1）概念的产生，基于软件包需求进行产品定义，并创建第一个功能原型；（2）设计，根据技术特征和要求，进行原型测试和产品的实施，通过广泛的测试验证产品的功能与规格；（3）发布，产品被制造出来并推向市场；（4）服务，对产品的维护，包括对客户的支持，最后不断优化，结束产品的周期。
+软件包的开发过程相当于完成了一项产品的制作，因此引入产品生命周期管理（PLM）的概念，PLM 包括以下四个阶段：（1）概念的产生，基于软件包需求进行产品定义，并创建第一个功能原型；（2）设计，根据技术特征和要求，进行原型测试和产品的实施，通过广泛的测试验证产品的功能与规格；（3）发布，产品被制造出来并推向市场；（4）服务，对产品的维护，包括对客户的支持，最后不断优化，结束产品的周期。
 
 在制作软件包时，主要面临以下几个过程：
 
 ![](media/b2be2d798f47f13077e4eafee94fad29.png)
 
-图1.5 软件包开发流程
+图 1.5 软件包开发流程
 
-首先，根据特定组件生成软件包即根据需求将相应的头文件、库文件等软件组件利用PDSC文件进行组织，在组织完成后即可利用软件包生成工具生成对应版本的软件包，然后对新生成的软件包进行测试，给出示例测试程序，再将其包含如PDSC文件中，最后经测试完成后生成最终的软件包。
+首先，根据特定组件生成软件包即根据需求将相应的头文件、库文件等软件组件利用 PDSC 文件进行组织，在组织完成后即可利用软件包生成工具生成对应版本的软件包，然后对新生成的软件包进行测试，给出示例测试程序，再将其包含如 PDSC 文件中，最后经测试完成后生成最终的软件包。
 
-### 1.2.2 利用STM32PackCreator制作软件包
+### 1.2.2 利用 STM32PackCreator 制作软件包
 
-STM32PackCreator能够通过图形化界面设计软件包，省去了我们手动编写PDSC文件和软件包生成脚本文件的步骤，使用起来非常方便快捷，以下是使用STM32PackCreator制作软件包的步骤。
+STM32PackCreator 能够通过图形化界面设计软件包，省去了我们手动编写 PDSC 文件和软件包生成脚本文件的步骤，使用起来非常方便快捷，以下是使用 STM32PackCreator 制作软件包的步骤。
 
-（1）打开STM32 PackCreator后，点击File-new project from scratch。
+（1）打开 STM32 PackCreator 后，点击 File-new project from scratch。
 
-![在这里插入图片描述](media/075a0efa2aac322fa7f04f18e494170c.png)
+![](media/075a0efa2aac322fa7f04f18e494170c.png)
 
-图1.6 生成新软件包
+图 1.6 生成新软件包
 
-（2）进行软件包的配置，包括软件包生成的文件夹、软件包的vendor、name和description属性。
+（2）进行软件包的配置，包括软件包生成的文件夹、软件包的 vendor、name 和 description 属性。
 
-![在这里插入图片描述](media/cc16fd410629fd560c7438445e30084f.png)
+![](media/cc16fd410629fd560c7438445e30084f.png)
 
-图1.7 软件包初始配置
+图 1.7 软件包初始配置
 
-（3）配置完成后，可以看到有四个属性栏，他们分别代表软件包的基本配置、版本控制、组件内容和附加文件，如图1.7所示：
+（3）配置完成后，可以看到有四个属性栏，他们分别代表软件包的基本配置、版本控制、组件内容和附加文件，如图 1.7 所示：
 
-![在这里插入图片描述](media/59fc851e13b1db9fa9967a14d720317b.png)
+![](media/59fc851e13b1db9fa9967a14d720317b.png)
 
-图1.8 软件包属性栏
+图 1.8 软件包属性栏
 
-（4）如下为制作Tencent OS-tiny软件包时的配置：
+（4）如下为制作 Tencent OS-tiny 软件包时的配置：
 
-![在这里插入图片描述](media/08f21f42eb03be8560ac0aa54248040d.png)
+![](media/08f21f42eb03be8560ac0aa54248040d.png)
 
 （a）基础配置
 
-![在这里插入图片描述](media/60608e9a968a8164576bec6fe00bdb99.png)
+![](media/60608e9a968a8164576bec6fe00bdb99.png)
 
 （b）软件包版本控制
 
-图1.9 软件包配置
+图 1.9 软件包配置
 
-（5）制作软件包的关键在于Pack
-Details的配置，这里实际上就是手工编写PDSC文件的图形化界面显示，我们按照ARM
-PDSC文件的编写规范设计condition、设计组件结构、添加组件即可。
+（5）制作软件包的关键在于 Pack
+Details 的配置，这里实际上就是手工编写 PDSC 文件的图形化界面显示，我们按照 ARM
+PDSC 文件的编写规范设计 condition、设计组件结构、添加组件即可。
 
-![在这里插入图片描述](media/0700d9cae7ef1ae1de93fc03bb09668d.png)
+![](media/0700d9cae7ef1ae1de93fc03bb09668d.png)
 
-图1.10 软件包组件配置
+图 1.10 软件包组件配置
 
-（6）添加附件，在Additional
-Files中，我们需要添加上软件包的说明文件（README.md）、利用软件包生成的示例工程（Projects）和STM32CubeMX文件夹，此时我们点击File-Save
+（6）添加附件，在 Additional
+Files 中，我们需要添加上软件包的说明文件（README.md）、利用软件包生成的示例工程（Projects）和 STM32CubeMX 文件夹，此时我们点击 File-Save
 and Generate
-Pack，可以在之前设定的路径下看到软件包。然后我们再次将这个软件包也加入到Additional
-Files中，如图1.11所示，我们再次点击File-Save and Generate
-Pack，就可以生成一个完整的STM32CubeMX软件包了。
+Pack，可以在之前设定的路径下看到软件包。然后我们再次将这个软件包也加入到 Additional
+Files 中，如图 1.11 所示，我们再次点击 File-Save and Generate
+Pack，就可以生成一个完整的 STM32CubeMX 软件包了。
 
 ![](media/4315430d5fce58833e07811993aab0ad.png)
 
-图1.11 STM32CubeMX文件夹
+图 1.11 STM32CubeMX 文件夹
 
 ![](media/9da795e383943b24b6502dcecbfc1720.png)
 
-图1.12 Additional Files界面
+图 1.12 Additional Files 界面
 
-![在这里插入图片描述](media/8f3894f199a4fd3f480f2b9d8881e45f.png)
+![](media/8f3894f199a4fd3f480f2b9d8881e45f.png)
 
 ![](media/a5518d6314ecc5d20dc9f5ddd21e4952.png)
 
-图1.13 生成软件包
+图 1.13 生成软件包
 
-（7）另外，STM32PackCreator提供了参数预先配置的功能，使得我们在STM32 Cube
-MX生成工程时，可以对软件包的参数进行提前配置。首先在图1.13(a)中添加我们需要用户提前配置的一系列参数，然后在图1.13(b)中制作一个模板文件，此处我设置为头文件的形式，然后将之前设置的一系列参数添加过来并保存，这样用户在使用软件包生成工程的时候就可以预先配置参数，并在生成工程时自动生成名为tos_config的文件。
+（7）另外，STM32PackCreator 提供了参数预先配置的功能，使得我们在 STM32 Cube
+MX 生成工程时，可以对软件包的参数进行提前配置。首先在图 1.13(a)中添加我们需要用户提前配置的一系列参数，然后在图 1.13(b)中制作一个模板文件，此处我设置为头文件的形式，然后将之前设置的一系列参数添加过来并保存，这样用户在使用软件包生成工程的时候就可以预先配置参数，并在生成工程时自动生成名为 tos_config 的文件。
 
 ![](media/7cfea692c4f0cf573994647241c2a666.png)
 ![](media/0dc47d61ee9335677e6f1230aaa2aa22.png)
 
 （a） （b）
 
-图1.14 软件包参数配置
+图 1.14 软件包参数配置
 
-# 2、TencentOS-tiny软件包
+# 2、TencentOS-tiny 软件包
 
 ## 2.1 软件包内容
 
-结合TencentOS tiny的算法架构，本文设计的软件包包括如表2-1所示的内容：
+结合 TencentOS tiny 的算法架构，本文设计的软件包包括如表 2-1 所示的内容：
 
-表2-1 软件包内容
+表 2-1 软件包内容
 
-| 内容     | 功能                                                                                                                          |                                              |
-|----------|-------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
-| arch     | 包括TencentOS-tiny\\arch\\arm下内核为Cortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23、Cortex-M33的arch文件 |                                              |
-| kernel   | 包括TencentOS-tiny\\kernel下的core、hal路径中的文件、tos_config文件                                                           |                                              |
-| cmsis_os | 对应TencentOS-tiny\\osal\\cmsis_os的文件                                                                                      |                                              |
-| example  | helloworld_main                                                                                                               | 用于测试软件包的main文件                     |
-|          | mcu_it.c                                                                                                                      | 移植软件包时需要按照该文件对中断函数进行修改 |
-|          | mcu_platform.h                                                                                                                | 用户可在此文件在添加对应单片机的头文件       |
+| 内容     | 功能                                                                                                                                |                                              |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| arch     | 包括 TencentOS-tiny\\arch\\arm 下内核为 Cortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23、Cortex-M33 的 arch 文件 |                                              |
+| kernel   | 包括 TencentOS-tiny\\kernel 下的 core、hal 路径中的文件、tos_config 文件                                                            |                                              |
+| cmsis_os | 对应 TencentOS-tiny\\osal\\cmsis_os 的文件                                                                                          |                                              |
+| example  | helloworld_main                                                                                                                     | 用于测试软件包的 main 文件                   |
+|          | mcu_it.c                                                                                                                            | 移植软件包时需要按照该文件对中断函数进行修改 |
+|          | mcu_platform.h                                                                                                                      | 用户可在此文件在添加对应单片机的头文件       |
 
 软件包具有以下功能：
 
-（1）软件包针对ARMCortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23和Cortex-M33内核进行了TencentOS
-tiny软件的封装，用户在安装软件包后能够快速将TencentOS tiny相应内核的Keil工程中；
+（1）软件包针对 ARMCortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23 和 Cortex-M33 内核进行了 TencentOS
+tiny 软件的封装，用户在安装软件包后能够快速将 TencentOS tiny 相应内核的 Keil 工程中；
 
-（2）软件包能够自动适应用户所选的内核，arch文件能够根据内核自动显示，从而方便用户使用；
+（2）软件包能够自动适应用户所选的内核，arch 文件能够根据内核自动显示，从而方便用户使用；
 
-（3）用户在勾选一个组件时，软件包会自动提示还需要勾选其他模块，并可利用界面中的Resolve一键勾选，防止遗漏；
+（3）用户在勾选一个组件时，软件包会自动提示还需要勾选其他模块，并可利用界面中的 Resolve 一键勾选，防止遗漏；
 
-（4）用户可在STM32CubeMX上修改tos_config文件中的参数，对TencentOS
-tiny的功能进行裁剪。
+（4）用户可在 STM32CubeMX 上修改 tos_config 文件中的参数，对 TencentOS
+tiny 的功能进行裁剪。
 
 ## 2.2 软件包安装
 
-接下来介绍Tencent.TencentOS-tiny软件包的安装，首先打开STM32 Cube
-MX软件，如图2.1(a)所示，点击INSTALL/REMOVE，然后将软件包拖进来，点击I agree to
+接下来介绍 Tencent.TencentOS-tiny 软件包的安装，首先打开 STM32 Cube
+MX 软件，如图 2.1(a)所示，点击 INSTALL/REMOVE，然后将软件包拖进来，点击 I agree to
 all the terms of the preceding License
-Agreement，再点击next进行安装，安装完成界面如图2.1(b)所示。
+Agreement，再点击 next 进行安装，安装完成界面如图 2.1(b)所示。
 
 ![](media/ba55cec0f5647efd53f9a8f4ee4dd49e.png)![](media/33809a718992a785c9601305ca1b2706.png)
 
 （a） （b）
 
-图2.1 软件包安装
+图 2.1 软件包安装
 
-安装好的软件包可以在安装路径中查看内容，路径在Help-Updater Settings中查看。
+安装好的软件包可以在安装路径中查看内容，路径在 Help-Updater Settings 中查看。
 
 ![](media/078139b6bd2274da5fa133a02e31707a.png)
 
@@ -300,55 +300,55 @@ Agreement，再点击next进行安装，安装完成界面如图2.1(b)所示。
 
 (b) 软件包安装查看
 
-图2.2 软件包安装
+图 2.2 软件包安装
 
 # 3、软件包测试
 
-## 3.1 STM32 MCU移植测试（生成STM32 CubeIDE工程）
+## 3.1 STM32 MCU 移植测试（生成 STM32 CubeIDE 工程）
 
 移植步骤如下：
 
-（1）点击ACCESS TO MCU SELECTOR：
+（1）点击 ACCESS TO MCU SELECTOR：
 
 ![](media/7d19cc0ecebfe342f6102fb63ddc48c0.png)
 
-图3.1 打开MCU选择的界面
+图 3.1 打开 MCU 选择的界面
 
-（2）选择STM32F407ZGTx，点击Start Project：
+（2）选择 STM32F407ZGTx，点击 Start Project：
 
 ![](media/1c357c9b931d9ca757cff186bea35cee.png)
 
-图3.2 选择MCU
+图 3.2 选择 MCU
 
 （3）点击红框中选项
 
 ![](media/f85e252032706686b1509648da2ad34b.png)
 
-图3.3 选择软件包
+图 3.3 选择软件包
 
-（4）此时生成使用STM32
-CubeIDE编译的工程，首先选择gcc版本的arch（如果是MDK-ARM版本的话就点击armcc版本的arch），然后点击黄色感叹号，再点击Resolve。之后手动添加helloworld_main和cmsis_os，并选择对应MCU版本的mcu_platform。最后点击ok完成配置。
+（4）此时生成使用 STM32
+CubeIDE 编译的工程，首先选择 gcc 版本的 arch（如果是 MDK-ARM 版本的话就点击 armcc 版本的 arch），然后点击黄色感叹号，再点击 Resolve。之后手动添加 helloworld_main 和 cmsis_os，并选择对应 MCU 版本的 mcu_platform。最后点击 ok 完成配置。
 
 ![](media/1cbb77bbe19809ad29348e80d449a28f.png)
 
 ![](media/9aa108534e529c9dc6974682d42ba98a.png)
 
-图3.4 软件包配置
+图 3.4 软件包配置
 
-（5）点击Software Packs，打勾，并在下方进行软件包的参数配置。
+（5）点击 Software Packs，打勾，并在下方进行软件包的参数配置。
 
 ![](media/80d8807155995bdfc49bfa6bb76a4f95.png)
 
-图3.5 软件包参数配置
+图 3.5 软件包参数配置
 
-（6）注释掉中断函数PendSV()、void
+（6）注释掉中断函数 PendSV()、void
 SysTick_Handler(void)等，这些在软件包中都进行了配置。
 
 ![](media/96c9b931cff86a48dbb47953b80ad114.png)
 
-图3.6 中断函数处理
+图 3.6 中断函数处理
 
-（7）进行生成工程配置，按如下界面进行配置，最后点击GENERATE CODE，并点击Open
+（7）进行生成工程配置，按如下界面进行配置，最后点击 GENERATE CODE，并点击 Open
 Project。
 
 ![](media/9dc4a0abb5af8ded362902f988d49697.png)
@@ -357,54 +357,53 @@ Project。
 
 ![](media/4c814923c4381488406c90a55e61b703.png)
 
-图3.7 工程生成配置
+图 3.7 工程生成配置
 
-（8）在tos_config头文件中加入头文件：**\#include**
-"mcu_platform_M4.h"，点击Build All，如下界面所示，编译通过，完成软件包的移植。
+（8）在 tos_config 头文件中加入头文件：`#include "mcu_platform_M4.h"`，点击 Build All，如下界面所示，编译通过，完成软件包的移植。
 
 ![](media/ebec579e6ab8041ad25a1b969a25f8ee.png)
 
-图3.8 工程配置与编译
+图 3.8 工程配置与编译
 
-## 3.2 STM32 Board移植测试（生成MDK-ARM v5工程）
+## 3.2 STM32 Board 移植测试（生成 MDK-ARM v5 工程）
 
-（1）点击ACCESS TO BOARD SELECTOR，选择Board为NUCLEO-F401RE，点击Start Project：
+（1）点击 ACCESS TO BOARD SELECTOR，选择 Board 为 NUCLEO-F401RE，点击 Start Project：
 
 ![](media/5f2d8da51e008ca34d307348243d4f79.png)
 
 ![](media/6d042e869f8150df48283e994a69a658.png)
 
-图3.9 Board选择
+图 3.9 Board 选择
 
 （2）点击红框中选项
 
 ![](media/f85e252032706686b1509648da2ad34b.png)
 
-图3.10 选择软件包
+图 3.10 选择软件包
 
-（3）此时生成使用MDK-ARM编译的工程，首先选择armcc版本的arch（如果是STM32
-CubeIDE版本的话就点击gcc版本的arch），然后点击黄色感叹号，再点击Resolve。之后手动添加helloworld_main和cmsis_os，并选择对应MCU版本的mcu_platform。最后点击ok完成配置。
+（3）此时生成使用 MDK-ARM 编译的工程，首先选择 armcc 版本的 arch（如果是 STM32
+CubeIDE 版本的话就点击 gcc 版本的 arch），然后点击黄色感叹号，再点击 Resolve。之后手动添加 helloworld_main 和 cmsis_os，并选择对应 MCU 版本的 mcu_platform。最后点击 ok 完成配置。
 
 ![](media/ad29e758a59f2cbaa4a3d2a9074f4cc4.png)
 
 ![](media/369b97c66d8f160c7f6e32237b22ecb7.png)
 
-图3.11 软件包配置
+图 3.11 软件包配置
 
-（4）点击Software Packs，打勾，并在下方进行软件包的参数配置。
+（4）点击 Software Packs，打勾，并在下方进行软件包的参数配置。
 
 ![](media/80d8807155995bdfc49bfa6bb76a4f95.png)
 
-图3.12 软件包参数配置
+图 3.12 软件包参数配置
 
-（5）注释掉中断函数PendSV()、void
+（5）注释掉中断函数 PendSV()、void
 SysTick_Handler(void)等，这些在软件包中都进行了配置。
 
 ![](media/96c9b931cff86a48dbb47953b80ad114.png)
 
-图3.13 中断函数处理
+图 3.13 中断函数处理
 
-（6）进行生成工程配置，按如下界面进行配置，最后点击GENERATE CODE，并点击Open
+（6）进行生成工程配置，按如下界面进行配置，最后点击 GENERATE CODE，并点击 Open
 Project。
 
 ![](media/c5e8dc1958c672144bfb2300540bd2ff.png)
@@ -413,51 +412,50 @@ Project。
 
 ![](media/f64c22f774625cc3e1df74194231ce98.png)
 
-图3.14 工程生成配置
+图 3.14 工程生成配置
 
-（8）打开main_example.c，跳转到tos_config头文件，在其中加入头文件：**\#include**
-"mcu_platform_M4.h"，点击Build All，如下界面所示，编译通过，完成软件包的移植。
+（8）打开 main_example.c，跳转到 tos_config 头文件，在其中加入头文件：`#include "mcu_platform_M4.h"`，点击 Build All，如下界面所示，编译通过，完成软件包的移植。
 
 ![](media/4682072cfe5bad6cbf4da59010037ddf.png)
 
-图3.15 移植编译
+图 3.15 移植编译
 
 ## 3.3 单片机测试
 
-对单片机开发板进行测试，以正点原子探索者STM32F407ZGT6为例介绍TencentOS-tiny软件包的移植。
+对单片机开发板进行测试，以正点原子探索者 STM32F407ZGT6 为例介绍 TencentOS-tiny 软件包的移植。
 
-（1）点击ACCESS TO MCU SELECTOR：
+（1）点击 ACCESS TO MCU SELECTOR：
 
 ![](media/7d19cc0ecebfe342f6102fb63ddc48c0.png)
 
-图3.16 打开MCU选择的界面
+图 3.16 打开 MCU 选择的界面
 
-（2）选择STM32F407ZGTx，点击Start Project：
+（2）选择 STM32F407ZGTx，点击 Start Project：
 
 ![](media/1c357c9b931d9ca757cff186bea35cee.png)
 
-图3.17 选择MCU
+图 3.17 选择 MCU
 
 （3）点击红框中选项
 
 ![](media/f85e252032706686b1509648da2ad34b.png)
 
-图3.18 选择软件包
+图 3.18 选择软件包
 
-（4）此时生成使用MDK-ARM编译的工程，首先选择armcc版本的arch（如果是STM32
-CubeIDE版本的话就点击gcc版本的arch），然后点击黄色感叹号，再点击Resolve。之后手动添加cmsis_os，并选择对应MCU版本的mcu_platform。最后点击ok完成配置。
+（4）此时生成使用 MDK-ARM 编译的工程，首先选择 armcc 版本的 arch（如果是 STM32
+CubeIDE 版本的话就点击 gcc 版本的 arch），然后点击黄色感叹号，再点击 Resolve。之后手动添加 cmsis_os，并选择对应 MCU 版本的 mcu_platform。最后点击 ok 完成配置。
 
 ![](media/42a491cb7b7351c6ab5db4fe11010a6b.png)
 
-图3.19 软件包配置
+图 3.19 软件包配置
 
-（5）点击Software Packs，打勾，并在下方进行软件包的参数配置。
+（5）点击 Software Packs，打勾，并在下方进行软件包的参数配置。
 
 ![](media/80d8807155995bdfc49bfa6bb76a4f95.png)
 
-图3.20 软件包参数配置
+图 3.20 软件包参数配置
 
-（6）注释掉中断函数PendSV()、void
+（6）注释掉中断函数 PendSV()、void
 SysTick_Handler(void)等，这些在软件包中都进行了配置，然后我们还需要对串口、下载等模块进行修改，如下：
 
 ![](media/96c9b931cff86a48dbb47953b80ad114.png)
@@ -470,187 +468,177 @@ SysTick_Handler(void)等，这些在软件包中都进行了配置，然后我�
 
 ![](media/44e4a8429efc9d8f3258bd455d7c5b9f.png)
 
-（c）RCC配置
+（c）RCC 配置
 
 ![](media/3655de0bd1a7df8340684ccc43aedfa9.png)
 
-（d）SYS配置
+（d）SYS 配置
 
 ![](media/d930f57f1821a959e0dd9f522a2a6c4f.png)
 
-（e）串口1配置
+（e）串口 1 配置
 
 ![](media/ef798ec862f32dc341a9d72777193977.png)
 
 （f）时钟树配置
 
-图3.21 模块配置
+图 3.21 模块配置
 
-（7）进行生成工程配置，按如下界面进行配置，最后点击右上角GENERATE
-CODE，生成工程后点击Open Project。
+（7）进行生成工程配置，按如下界面进行配置，最后点击右上角 GENERATE
+CODE，生成工程后点击 Open Project。
 
 ![](media/726701d4d352048af6380ee3fb7dd31e.png)
 
 ![](media/82fd548a37df739720f71faa065b7dde.png)
 
-图3.22 工程配置
+图 3.22 工程配置
 
-（8）打开tos_config头文件，在其中加入头文件：**\#include**
-"mcu_platform_M4.h"，然后使用如下的main文件：
+（8）打开 tos_config 头文件，在其中加入头文件：`#include "mcu_platform_M4.h"`，然后使用如下的 main 文件：
 
-/\* USER CODE BEGIN Includes \*/
+```c
+/* USER CODE BEGIN Includes */
 
-\#include "cmsis_os.h"
+#include "cmsis_os.h"
 
-/\* USER CODE END Includes \*/
+/* USER CODE END Includes */
 
-/\* USER CODE BEGIN 0 \*/
+/* USER CODE BEGIN 0 */
 
 //task1
 
-\#define TASK1_STK_SIZE 512
+#define TASK1_STK_SIZE 512
 
-void task1(void \*pdata);
+void task1(void *pdata);
 
 osThreadDef(task1, osPriorityNormal, 1, TASK1_STK_SIZE);
 
 //task2
 
-\#define TASK2_STK_SIZE 512
+#define TASK2_STK_SIZE 512
 
-void task2(void \*pdata);
+void task2(void *pdata);
 
 osThreadDef(task2, osPriorityNormal, 1, TASK2_STK_SIZE);
 
-void task1(void \*pdata)
+void task1(void *pdata)
+{
 
+    int count = 1;
+
+    char buffer[64] = {0};
+
+    while(1) {
+        snprintf(buffer, sizeof(buffer), "task 1 %04d\r\n", count++);
+
+        HAL_UART_Transmit(&huart1, (uint8_t*)buffer, strlen(buffer), 0xFFFF);
+
+        osDelay(2000);
+    }
+
+}
+
+void task2(void *pdata)
 {
 
 int count = 1;
 
 char buffer[64] = {0};
 
-while(1) {
+    while(1) {
 
-snprintf(buffer, sizeof(buffer), "task 1 %04d\\r\\n", count++);
+        snprintf(buffer, sizeof(buffer), "task 2 %04d\r\n", count++);
 
-HAL_UART_Transmit(&huart1, (uint8_t\*)buffer, strlen(buffer), 0xFFFF);
+        HAL_UART_Transmit(&huart1, (uint8_t\*)buffer, strlen(buffer), 0xFFFF);
 
-osDelay(2000);
+        osDelay(1000);
 
-}
-
-}
-
-void task2(void \*pdata)
-
-{
-
-int count = 1;
-
-char buffer[64] = {0};
-
-while(1) {
-
-snprintf(buffer, sizeof(buffer), "task 2 %04d\\r\\n", count++);
-
-HAL_UART_Transmit(&huart1, (uint8_t\*)buffer, strlen(buffer), 0xFFFF);
-
-osDelay(1000);
+    }
 
 }
 
-}
-
-/\* USER CODE END 0 \*/
+/* USER CODE END 0 */
 
 int main(void)
-
 {
+    /* USER CODE BEGIN 1 */
 
-/\* USER CODE BEGIN 1 \*/
+    /* USER CODE END 1 */
 
-/\* USER CODE END 1 \*/
+    /* MCU Configuration--------------------------------------------------------*/
 
-/\* MCU Configuration--------------------------------------------------------\*/
+    /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
 
-/\* Reset of all peripherals, Initializes the Flash interface and the Systick.
-\*/
+    HAL_Init();
 
-HAL_Init();
+    /* USER CODE BEGIN Init */
 
-/\* USER CODE BEGIN Init \*/
+    /* USER CODE END Init */
 
-/\* USER CODE END Init \*/
+    /* Configure the system clock */
 
-/\* Configure the system clock \*/
+    SystemClock_Config();
 
-SystemClock_Config();
+    /* USER CODE BEGIN SysInit */
 
-/\* USER CODE BEGIN SysInit \*/
+    /* USER CODE END SysInit */
 
-/\* USER CODE END SysInit \*/
+    /* Initialize all configured peripherals */
 
-/\* Initialize all configured peripherals \*/
+    MX_GPIO_Init();
 
-MX_GPIO_Init();
+    MX_USART1_UART_Init();
 
-MX_USART1_UART_Init();
+    /* USER CODE BEGIN 2 */
 
-/\* USER CODE BEGIN 2 \*/
+    osKernelInitialize(); //TOS Tiny kernel initialize
 
-osKernelInitialize(); //TOS Tiny kernel initialize
+    osThreadCreate(osThread(task1), NULL);// Create task1
 
-osThreadCreate(osThread(task1), NULL);// Create task1
+    osThreadCreate(osThread(task2), NULL);// Create task2
 
-osThreadCreate(osThread(task2), NULL);// Create task2
+    osKernelStart(); //Start TOS Tiny
 
-osKernelStart(); //Start TOS Tiny
+    /* USER CODE END 2 */
 
-/\* USER CODE END 2 \*/
+    /* Infinite loop */
 
-/\* Infinite loop \*/
+    /* USER CODE BEGIN WHILE */
 
-/\* USER CODE BEGIN WHILE \*/
+    while (1)
+    {
+        /* USER CODE END WHILE */
 
-while (1)
+        /* USER CODE BEGIN 3 */
+    }
 
-{
-
-/\* USER CODE END WHILE \*/
-
-/\* USER CODE BEGIN 3 \*/
-
+    /* USER CODE END 3 */
 }
+```
 
-/\* USER CODE END 3 \*/
-
-}
-
-（9）编译，然后使用ST-LINK下载到正点原子探索者单片机中
+（9）编译，然后使用 ST-LINK 下载到正点原子探索者单片机中
 
 ![](media/e5fa29fccefcb0cf1675ab7e763fa087.png)
 
-图3.23 编译、下载程序
+图 3.23 编译、下载程序
 
 （10）使用串口助手查看，两个任务的延时设置不一样，运行效果也不一样：
 
 ![](media/c1a77804bb7bdff73a478692034146cd.png)
 
-图3.24 串口查看界面
+图 3.24 串口查看界面
 
 # 4、开发参考
 
 1、腾讯物联网操作系统网址<https://github.com/OpenAtomFoundation/TencentOS-tiny>
 
-2、ST官方教程[How to develop a STM32Cube Expansion Package - stm32mcu
+2、ST 官方教程[How to develop a STM32Cube Expansion Package - stm32mcu
 (stmicroelectronics.cn)](https://wiki.stmicroelectronics.cn/stm32mcu/wiki/How_to_develop_a_STM32Cube_Expansion_Package)
 
-3、[制作STM32Cube软件包-STM32 PackCreator的使用及软件包的制作 - 极术社区 -
+3、[制作 STM32Cube 软件包-STM32 PackCreator 的使用及软件包的制作 - 极术社区 -
 连接开发者与智能计算生态 (aijishu.com)](https://aijishu.com/a/1060000000243533)
 
 4、[（1）STM32
-CubeMX软件包的制作---STM32PackCreator的使用_linwei_Cui的博客-CSDN博客](https://blog.csdn.net/qq_40259429/article/details/120557456?spm=1001.2014.3001.5501)
+CubeMX 软件包的制作---STM32PackCreator 的使用\_linwei_Cui 的博客-CSDN 博客](https://blog.csdn.net/qq_40259429/article/details/120557456?spm=1001.2014.3001.5501)
 
 5、[（2）STM32
-CubeMX软件包的制作---简易软件包的制作_linwei_Cui的博客-CSDN博客](https://blog.csdn.net/qq_40259429/article/details/120583659?spm=1001.2014.3001.5501)
+CubeMX 软件包的制作---简易软件包的制作\_linwei_Cui 的博客-CSDN 博客](https://blog.csdn.net/qq_40259429/article/details/120583659?spm=1001.2014.3001.5501)

--- a/tools/STM32CubeMX_pack/README.md
+++ b/tools/STM32CubeMX_pack/README.md
@@ -1,32 +1,36 @@
-# 基于STM32 CubeMX开发的TencentOS-Tiny Software Pack v1.0.0
-##TencentOS-Tiny 1.0.0
+# 基于 STM32 CubeMX 开发的 TencentOS-Tiny Software Pack v1.0.0
+
+## TencentOS-Tiny 1.0.0
+
 软件包具有以下功能：
 
-	（1）软件包针对ARM Cortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23和Cortex-M33内核进行了TencentOS tiny操作系统的封装，在安装软件包后能够快速将TencentOS tiny相应内核的Keil工程中；
-	（2）软件包能够自动适应工程所选的内核，arch文件能够根据内核自动显示；
-	（3）用户在勾选一个组件时，软件包会自动提示还需要勾选其他模块，并可利用界面中的Resolve一键勾选；
-	（4）用户可自主修改对应内核的tos_config文件，对TencentOS tiny的功能进行裁剪；
-	（5）目前软件包已经在STM32 CubeMX 6.2.0上进行了测试，完成了基于ARM Cortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7和Cortex-M33内核的ST芯片以及单片机移植测试。
+    （1）软件包针对ARM Cortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23和Cortex-M33内核进行了TencentOS tiny操作系统的封装，在安装软件包后能够快速将TencentOS tiny相应内核的Keil工程中；
+    （2）软件包能够自动适应工程所选的内核，arch文件能够根据内核自动显示；
+    （3）用户在勾选一个组件时，软件包会自动提示还需要勾选其他模块，并可利用界面中的Resolve一键勾选；
+    （4）用户可自主修改对应内核的tos_config文件，对TencentOS tiny的功能进行裁剪；
+    （5）目前软件包已经在STM32 CubeMX 6.2.0上进行了测试，完成了基于ARM Cortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7和Cortex-M33内核的ST芯片以及单片机移植测试。
 
-CSDN博客: <https://blog.csdn.net/qq_40259429/article/details/121334816>
+CSDN 博客: <https://blog.csdn.net/qq_40259429/article/details/121334816>
 
 极术社区：[https://aijishu.com/a/1060000000243533](https://aijishu.com/a/1060000000243533 "STM32 CubeMX软件包制作")
 
-TencentOS Tiny GitHub网页: <https://github.com/OpenAtomFoundation/TencentOS-tiny/tree/master/tools/STM32CubeMX_pack>
-
+TencentOS Tiny GitHub 网页: <https://github.com/OpenAtomFoundation/TencentOS-tiny/tree/master/tools/STM32CubeMX_pack>
 
 # TencentOS-Tiny Software Pack v1.0.0 based on STM32 CubeMX
-##TencentOS-Tiny 1.0.0
+
+## TencentOS-Tiny 1.0.0
+
 The software pack has the following features:
 
-	Updated new pack:
-	(1) The package packages the TencentOS tiny operating system for the ARM Cortex-M0+, Cortex-M0, Cortex-M3, Cortex-M4, Cortex-M7, Cortex-M23 and Cortex-M33 cores, enabling quick installation of the TencentOS tiny corresponding kernel in a Keil project.
-	(2) The package can automatically adapt to the kernel selected for the project, and the arch file can be displayed automatically according to the kernel.
-	(3) When the user checks a component, the package will automatically indicate that other modules need to be checked, and can be checked with one click using Resolve in the interface.
-	(4) The user can modify the tos_config file of the corresponding kernel to tailor the functions of TencentOS tiny on their own.
-	(5) The package has been tested on STM32 CubeIDE 6.2.0, completed with core-based based chips and microcontroller development boards based on ARM Cortex-M0+, Cortex-M0, Cortex-M3, Cortex-M4, Cortex-M7, Cortex-M33 cores were ported.
+    Updated new pack:
+    (1) The package packages the TencentOS tiny operating system for the ARM Cortex-M0+, Cortex-M0, Cortex-M3, Cortex-M4, Cortex-M7, Cortex-M23 and Cortex-M33 cores, enabling quick installation of the TencentOS tiny corresponding kernel in a Keil project.
+    (2) The package can automatically adapt to the kernel selected for the project, and the arch file can be displayed automatically according to the kernel.
+    (3) When the user checks a component, the package will automatically indicate that other modules need to be checked, and can be checked with one click using Resolve in the interface.
+    (4) The user can modify the tos_config file of the corresponding kernel to tailor the functions of TencentOS tiny on their own.
+    (5) The package has been tested on STM32 CubeIDE 6.2.0, completed with core-based based chips and microcontroller development boards based on ARM Cortex-M0+, Cortex-M0, Cortex-M3, Cortex-M4, Cortex-M7, Cortex-M33 cores were ported.
 
 web of TencentOS Tiny: <https://github.com/OpenAtomFoundation/TencentOS-tiny/tree/master/tools/mdk_pack>
-# License
-Licensed under BSD 3-Clause License.
 
+# License
+
+Licensed under BSD 3-Clause License.

--- a/tools/mdk_pack/Documentation/README.md
+++ b/tools/mdk_pack/Documentation/README.md
@@ -1,6 +1,6 @@
 ![](media/354799faf95c55a28fe89a774163e7c7.png)
 
-# 基于MDK开发的TencentOS-Tiny Software Pack
+# 基于 MDK 开发的 TencentOS-Tiny Software Pack
 
 TencentOS-Tiny software package based on MDK development
 
@@ -20,7 +20,7 @@ Email：1797878653@qq.com
 
 目录
 
-[1、ARM软件包介绍](#1arm软件包介绍)
+[1、ARM 软件包介绍](#1arm软件包介绍)
 
 [1.1 软件包简介](#11-软件包简介)
 
@@ -28,11 +28,11 @@ Email：1797878653@qq.com
 
 [1.2.1 软件包开发过程](#121-软件包开发过程)
 
-[1.2.2 PDSC文件的编写](#122-pdsc文件的编写)
+[1.2.2 PDSC 文件的编写](#122-pdsc文件的编写)
 
 [1.2.3 生成软件包](#123-生成软件包)
 
-[2、TencentOS-tiny软件包](#2tencentos-tiny软件包)
+[2、TencentOS-tiny 软件包](#2tencentos-tiny软件包)
 
 [2.1 软件包内容](#21-软件包内容)
 
@@ -40,9 +40,9 @@ Email：1797878653@qq.com
 
 [3、软件包测试](#3软件包测试)
 
-[3.1 ARM内核移植TencentOS tiny软件包](#31-arm内核移植tencentos-tiny软件包)
+[3.1 ARM 内核移植 TencentOS tiny 软件包](#31-arm内核移植tencentos-tiny软件包)
 
-[3.2 STM32不依赖裸机工程移植](#32-stm32不依赖裸机工程移植)
+[3.2 STM32 不依赖裸机工程移植](#32-stm32不依赖裸机工程移植)
 
 [3.3 单片机裸机工程移植](#33-单片机裸机工程移植)
 
@@ -52,39 +52,39 @@ Email：1797878653@qq.com
 
 [6、附录-移植配置参考](#6附录-移植配置参考)
 
-[6.1 MDK5.14版本移植到ARM内核](#61-mdk514版本移植到arm内核)
+[6.1 MDK5.14 版本移植到 ARM 内核](#61-mdk514版本移植到arm内核)
 
-[6.1.1 Cortex-M0内核移植](#611-cortex-m0内核移植)
+[6.1.1 Cortex-M0 内核移植](#611-cortex-m0内核移植)
 
 [6.1.2 Cortex-M0+内核移植](#612-cortex-m0内核移植)
 
-[6.1.3 Cortex-M3内核移植](#613-cortex-m3内核移植)
+[6.1.3 Cortex-M3 内核移植](#613-cortex-m3内核移植)
 
-[6.1.4 Cortex-M4内核移植](#614-cortex-m4内核移植)
+[6.1.4 Cortex-M4 内核移植](#614-cortex-m4内核移植)
 
-[6.1.5 Cortex-M7内核移植](#615-cortex-m7内核移植)
+[6.1.5 Cortex-M7 内核移植](#615-cortex-m7内核移植)
 
-[6.2 MDK5.14版本移植到基于ARM内核的芯片](#62-mdk514版本移植到基于arm内核的芯片)
+[6.2 MDK5.14 版本移植到基于 ARM 内核的芯片](#62-mdk514版本移植到基于arm内核的芯片)
 
-[6.2.1 移植到stm32f103c8芯片](#621-移植到stm32f103c8芯片)
+[6.2.1 移植到 stm32f103c8 芯片](#621-移植到stm32f103c8芯片)
 
-[6.2.2 移植到stm32f767igt芯片](#622-移植到stm32f767igt芯片)
+[6.2.2 移植到 stm32f767igt 芯片](#622-移植到stm32f767igt芯片)
 
 [6.3
-MDK5.30和MDK5.35版本移植（Cortex-M0+、0、3、4、7内核和芯片）](#63-mdk530和mdk535版本移植cortex-m00347内核和芯片)
+MDK5.30 和 MDK5.35 版本移植（Cortex-M0+、0、3、4、7 内核和芯片）](#63-mdk530和mdk535版本移植cortex-m00347内核和芯片)
 
 [6.4
-MDK5.30和MDK5.35版本移植（Cortex-M23、33）](#64-mdk530和mdk535版本移植cortex-m2333)
+MDK5.30 和 MDK5.35 版本移植（Cortex-M23、33）](#64-mdk530和mdk535版本移植cortex-m2333)
 
-[6.4.1 Cortex-M23内核移植](#641-cortex-m23内核移植)
+[6.4.1 Cortex-M23 内核移植](#641-cortex-m23内核移植)
 
-[6.4.2 Cortex-M33内核移植](#642-cortex-m33内核移植)
+[6.4.2 Cortex-M33 内核移植](#642-cortex-m33内核移植)
 
-# 1、ARM软件包介绍
+# 1、ARM 软件包介绍
 
 ## 1.1 软件包简介
 
-在进行嵌入式软件开发时，ARM为我们提供了软件包功能，能够将软件算法等模块进行集成封装，从而方便第三方用户使用。ARM软件包能够为微控制器设备和开发板提供支持，包含软件组件（Software
+在进行嵌入式软件开发时，ARM 为我们提供了软件包功能，能够将软件算法等模块进行集成封装，从而方便第三方用户使用。ARM 软件包能够为微控制器设备和开发板提供支持，包含软件组件（Software
 Component）如驱动程序和中间件，还可以包含示例项目和代码模板等，主要有以下类型的软件包：
 
 (1) 器件系列包（Device Family
@@ -93,7 +93,7 @@ Pack）：由硅供应商或工具供应商生成，为特定的目标微控制�
 (2) 板级支持包（Board Support
 Pack）：由电路板供应商发布，为安装在电路板上的外围硬件提供软件支持。
 
-(3) CMSIS软件包：由ARM提供，包括对CMSIS核心、DSP和RTOS的支持；
+(3) CMSIS 软件包：由 ARM 提供，包括对 CMSIS 核心、DSP 和 RTOS 的支持；
 
 (4) 中间件包（Middleware
 Pack）：由芯片供应商、工具供应商或第三方创建；通过提供对常用软件组件（如软件堆栈、特殊硬件库等）的软件集成，从而减少开发时间；
@@ -108,238 +108,191 @@ Pack）：由芯片供应商、工具供应商或第三方创建；通过提供�
 
 (3) 代码模板，方便使用软件组件。
 
-一个完整的软件包是一个ZIP文件，包含所有需要的软件库和文件，以及一个包含软件包所有信息的包描述文件（PDSC文件），软件包的结构是在CMSIS中定义的(<http://www.keil.com/CMSIS/Pack>)。
+一个完整的软件包是一个 ZIP 文件，包含所有需要的软件库和文件，以及一个包含软件包所有信息的包描述文件（PDSC 文件），软件包的结构是在 CMSIS 中定义的(<http://www.keil.com/CMSIS/Pack>)。
 
 ## 1.2 软件包开发
 
 ### 1.2.1 软件包开发过程
 
-软件包的开发过程相当于完成了一项产品的制作，因此引入产品生命周期管理（PLM）的概念，PLM包括以下四个阶段：（1）概念的产生，基于软件包需求进行产品定义，并创建第一个功能原型；（2）设计，根据技术特征和要求，进行原型测试和产品的实施，通过广泛的测试验证产品的功能与规格；（3）发布，产品被制造出来并推向市场；（4）服务，对产品的维护，包括对客户的支持，最后不断优化，结束产品的周期。
+软件包的开发过程相当于完成了一项产品的制作，因此引入产品生命周期管理（PLM）的概念，PLM 包括以下四个阶段：（1）概念的产生，基于软件包需求进行产品定义，并创建第一个功能原型；（2）设计，根据技术特征和要求，进行原型测试和产品的实施，通过广泛的测试验证产品的功能与规格；（3）发布，产品被制造出来并推向市场；（4）服务，对产品的维护，包括对客户的支持，最后不断优化，结束产品的周期。
 
 在制作软件包时，主要面临以下几个过程：
 
 ![](media/b2be2d798f47f13077e4eafee94fad29.png)
 
-图1.1 软件包开发流程
+图 1.1 软件包开发流程
 
-首先，根据特定组件生成软件包即根据需求将相应的头文件、库文件等软件组件利用PDSC文件进行组织，在组织完成后即可利用软件包生成工具生成对应版本的软件包，然后对新生成的软件包进行测试，给出示例测试程序，再将其包含如PDSC文件中，最后经测试完成后生成最终的软件包。
+首先，根据特定组件生成软件包即根据需求将相应的头文件、库文件等软件组件利用 PDSC 文件进行组织，在组织完成后即可利用软件包生成工具生成对应版本的软件包，然后对新生成的软件包进行测试，给出示例测试程序，再将其包含如 PDSC 文件中，最后经测试完成后生成最终的软件包。
 
-### 1.2.2 PDSC文件的编写
+### 1.2.2 PDSC 文件的编写
 
-PDSC文件时基于可扩展标记语言（XML）进行编写的，能够将软件包包含的各个模块按照特定的格式组织起来，接下来按照PDSC文件的结构对文件的编写进行详细介绍：
+PDSC 文件时基于可扩展标记语言（XML）进行编写的，能够将软件包包含的各个模块按照特定的格式组织起来，接下来按照 PDSC 文件的结构对文件的编写进行详细介绍：
 
-首先是PDSC文件的开头，前两句是声明为XML格式，它是在MDK中的PACK.xsd文件定义的，所以不用修改；\<name\>和\<vendor\>标签定义了软件包的基本内容，也用于PACK文件的文件名，故该PDSC文件应命名为Tencent.TencentOS-tiny.pdsc；\<
-description
-\>标签描述了软件包的信息，它将显示在包安装程序中；\<url\>标签可以包含一个带有软件包下载链接的网址，方便用户下载；\<
-license \>标签包含了用户使用该软件包时需要遵守的协议，\< supportContact
-\>标签表示软件包的支持人员联系方式，可以提供一个电子邮件地址或网页URL。如图1.2为下列代码对应的软件包界面。
+首先是 PDSC 文件的开头，前两句是声明为 XML 格式，它是在 MDK 中的 PACK.xsd 文件定义的，所以不用修改；
+`<name>`和`<vendor>`标签定义了软件包的基本内容，也用于 PACK 文件的文件名，故该 PDSC 文件应命名为`Tencent.TencentOS-tiny.pdsc`；
+`<description>`标签描述了软件包的信息，它将显示在包安装程序中；
+`<url>`标签可以包含一个带有软件包下载链接的网址，方便用户下载；
+`<license >`标签包含了用户使用该软件包时需要遵守的协议，
+`< supportContact>`标签表示软件包的支持人员联系方式，可以提供一个电子邮件地址或网页 URL。如图 1.2 为下列代码对应的软件包界面。
 
-\<?xml version="1.0" encoding="utf-8"?\>
-
-\<package schemaVersion="1.0"
-xmlns:xs=<http://www.w3.org/2001/XMLSchema-instance>
-xs:noNamespaceSchemaLocation="PACK.xsd"\>
-
-\<name\>Tencent\</name\>
-
-\<description\>Description of your pack\</description\>
-
-\<vendor\>TencentOS-tiny\</vendor\>
-
-\<url\>[https://github.com/OpenAtomFoundation/TencentOS-tiny](https://github.com/OpenAtomFoundation/TencentOS-tiny)\</url\>
-
-\<license\>LICENSE.txt\</license\>
-
-\<supportContact\>…\</supportContact\>
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package schemaVersion="1.0"
+	xmlns:xs=
+	<http://www.w3.org/2001/XMLSchema-instance>
+xs:noNamespaceSchemaLocation="PACK.xsd">
+		<name>Tencent</name>
+		<description>Description of your pack</description>
+		<vendor>TencentOS-tiny</vendor>
+		<url>[https://github.com/OpenAtomFoundation/TencentOS-tiny](https://github.com/OpenAtomFoundation/TencentOS-tiny)</url>
+		<license>LICENSE.txt</license>
+		<supportContact>…</supportContact>
+```
 
 ![](media/d014da7b13995d39b87cefa44a147e03.png)
 
-图1.2 程序对应的软件包
+图 1.2 程序对应的软件包
 
-接下来是PDSC文件的各个模块，\<releases\>标签定义了软件包的版本，开发者可以在版本更新时在此进行标注，从而在生成软件包时，系统会自动生成最新版本的软件包；
+接下来是 PDSC 文件的各个模块，`<releases>`标签定义了软件包的版本，开发者可以在版本更新时在此进行标注，从而在生成软件包时，系统会自动生成最新版本的软件包；
 
-\<releases\>
-
-\<release version=**"1.0.1"**\>
+```xml
+<releases>
+	<release version=**"1.0.1"**>
 
 Sep/3/2021, version name
 
-\</release\>
-
-\<release version=**"1.0.0"**\>
+</release>
+	<release version=**"1.0.0"**>
 
 Sep/1/2021, version name
 
-\</release\>
+</release>
+</releases>
+```
 
-\</releases\>
+`<taxonomy>`标签用于定义每个组件的 description，如图 1.3 所示，通过下列代码中的 Cclass、Cgroup 和 Csub 来确定 description 所在的位置，doc 用于指定 description 文件（也可以不加），然后添加 description 的名字。
 
-\<taxonomy\>标签用于定义每个组件的description，如图1.3所示，通过下列代码中的Cclass、Cgroup和Csub来确定description所在的位置，doc用于指定description文件（也可以不加），然后添加description的名字。
-
-\<taxonomy\>
-
-\<description Cclass="TencentOS tiny" Cgroup="xx" Csub="xx"
-doc="examples/index.html"\>TencentOS tiny\</description\> \<!—添加网页功能 --\>
-
-\</taxonomy\>
+```xml
+<taxonomy>
+	<description Cclass="TencentOS tiny" Cgroup="xx" Csub="xx"
+doc="examples/index.html">TencentOS tiny</description>
+	<!-- 添加网页功能 -->
+</taxonomy>
+```
 
 ![](media/814a3eecfc04f2bbc24108cedce23ebf.png)
 
-图1.3 \<taxonomy\>标签
+图 1.3 `<taxonomy>`标签
 
-\< keywords
-\>标签定义了软件包的关键词，在ARM官网下载软件包时可利用关键词搜索到需要的软件包。
+`< keywords>`标签定义了软件包的关键词，在 ARM 官网下载软件包时可利用关键词搜索到需要的软件包。
 
-\<keywords \>
+```xml
+<keywords>
+	<keyword>Tencent</keyword>
+</keywords>
+```
 
-\<keyword\>Tencent\</keyword\>
+`< requirements>`标签定义了软件包的关联安装需求，即在安装本软件包时，还需要在网上安装其他包（网址：MDK5
+Software Packs (keil.com)），例如下面的定义则需要我们安装 ARM 的 CMSIS5.7.0 软件包。
 
-\</keywords \>
+```xml
+<requirements>
+	<packages>
+		<package vendor="ARM" name="CMSIS" version="5.7.0"/>
+	</packages>
+</requirements>
+```
 
-\< requirements
-\>标签定义了软件包的关联安装需求，即在安装本软件包时，还需要在网上安装其他包（网址：MDK5
-Software Packs (keil.com)），例如下面的定义则需要我们安装ARM的CMSIS5.7.0软件包。
+接下来是`<conditions>`标签，该标签在设计`<components>`时使用，用以说明软件包中各个组件的依赖关系，即使用本组件还需要选择其他组件。在该标签下可以定义多个 condition，每个 condition 可以定义多个条件。
+其中`<conditions id>`表示条件名，`<description>`为条件信息，然后便是定义的条件，其中`<accept>`表示该条件时可选的，当同时存在多个`<accept>`时，用户需要至少满足其中一个条件才可以使用；`<require>`表示该条件是必选的，否则便无法使用相应的组件。在条件内部，包含一些特定的指示性语法，如果在设计`<component>`的时候开发者选择了名为 Cortex_M0 的条件，那么用户在使用该`<component>`时，则需要遵守条件要求：其中`<accept Dvendor="ARM:82" Dname="ARMCM0"/>`表示用户选择 ARM-Cortex
+M0 内核时才会触发该条件，`<require condition="condition id"/>`为条件嵌套，表示用户还需要满足嵌套条件对应的要求，
+`<require Cclass="TencentOS tiny" Cgroup="kernel" Csub="core"/>`表示用户还需要选择 core 组件。
 
-\<requirements\>
+```xml
+<conditions>
+	<condition id="Cortex_M0">
+		<description> Cortex-M0</description>
+		<accept Dvendor="ARM:82" Dname="ARMCM0"/>
+		<require condition="condition id "/>
+		< require Tcompiler="ARMCC"/>
+		<require Cclass="TencentOS tiny" Cgroup="kernel" Csub="core"/>
+	</condition>
+	<condition id=" condition_2 ">
+		<description></description>
+		<!-- 第二个condition的内容 -->
+	</condition>
+</conditions>
+```
 
-\<packages\>
-
-\<package vendor="ARM" name="CMSIS" version="5.7.0"/\>
-
-\</packages\>
-
-\</requirements\>
-
-接下来是\<conditions\>标签，该标签在设计\<components\>时使用，用以说明软件包中各个组件的依赖关系，即使用本组件还需要选择其他组件。在该标签下可以定义多个condition，每个condition可以定义多个条件。其中\<conditions
-id\>表示条件名，\<description\>为条件信息，然后便是定义的条件，其中\<accept\>表示该条件时可选的，当同时存在多个\<accept\>时，用户需要至少满足其中一个条件才可以使用；\<require\>表示该条件是必选的，否则便无法使用相应的组件。在条件内部，包含一些特定的指示性语法，如果在设计\<component\>的时候开发者选择了名为Cortex_M0的条件，那么用户在使用该\<component\>时，则需要遵守条件要求：其中\<accept
-Dvendor="ARM:82" Dname="ARMCM0"/\>表示用户选择ARM-Cortex
-M0内核时才会触发该条件，\<require condition="condition id
-"/\>为条件嵌套，表示用户还需要满足嵌套条件对应的要求，\<require
-Cclass="TencentOS tiny" Cgroup="kernel"
-Csub="core"/\>表示用户还需要选择core组件。
-
-\<conditions\>
-
-\<condition id="Cortex_M0"\>
-
-\<description\> Cortex-M0\</description\>
-
-\<accept Dvendor="ARM:82" Dname="ARMCM0"/\>
-
-\<require condition="condition id "/\>
-
-\< require Tcompiler="ARMCC"/\>
-
-\<require Cclass="TencentOS tiny" Cgroup="kernel" Csub="core"/\>
-
-\</condition\>
-
-\<condition id=" condition_2 "\>
-
-\<description\>\</description\>
-
-\<!-- 第二个condition的内容 --\>
-
-\</condition\>
-
-\</conditions\>
-
-然后是\<components\>标签，该标签描述了软件包包含的所有文件，在编写该标签下的程序时，需要按照文件类别将文件进行划分，在下列代码中，定义了一个Keil::
+然后是`<components>`标签，该标签描述了软件包包含的所有文件，在编写该标签下的程序时，需要按照文件类别将文件进行划分，在下列代码中，定义了一个 Keil::
 TencentOS tiny::
-arch::arch的\<component\>，\<description\>为该组件的信息，具体如图1.4所示。
+arch::arch 的`<component>`，`<description>`为该组件的信息，具体如图 1.4 所示。
 
 ![](media/df78bafba8926434183546dce81e2926.png)
 
-图1.4 \<component\>定义界面
+图 1.4 `<component``>定义界面
 
-\<components\>
-
-\<component Cvendor="Keil" Cclass="TencentOS tiny" Cgroup="arch" Csub="arch"
-Cversion="1.0.1" condition=" condition id"\>
-
-\<description\> description \</description\>
-
-\<files\>
-
-\<file category="doc" name="Documentation/General/html/driver_I2C.html"/\>--\>
-
-\<file category="include" name="arch/arm/arm-v7m/common/include/"/\>
-
-\<file category="header" name="arch/arm/arm-v7m/cortex-m0+/armcc/port.h"/\>
-
-\<file category="header" name="arch/arm/arm-v7m/cortex-m0+/armcc/port_config.h"
-attr="config"
-
-version="1.1.0"/\>
-
-\<file category="source" name="arch/arm/arm-v7m/common/tos_cpu.c"/\>
-
-\</files\>
-
-\</component\>
-
-\</components\>
+```xml
+<components>
+	<component Cvendor="Keil" Cclass="TencentOS tiny" Cgroup="arch" Csub="arch"
+Cversion="1.0.1" condition=" condition id">
+		<description> description </description>
+		<files><file category="doc" name="Documentation/General/html/driver_I2C.html"/>
+			<file category="include" name="arch/arm/arm-v7m/common/include/"/>
+			<file category="header" name="arch/arm/arm-v7m/cortex-m0+/armcc/port.h"/>
+			<file category="header" name="arch/arm/arm-v7m/cortex-m0+/armcc/port_config.h" attr="config" version="1.1.0"/>
+			<file category="source" name="arch/arm/arm-v7m/common/tos_cpu.c"/>
+		</files>
+	</component>
+</components>
+```
 
 condition=" condition
-id"即为上述介绍的\<condition\>标签，从而用户在使用该组件时，还需要满足condition所要求的依赖组件。另外，在定义某一个\<component\>时，需要按照上面程序的\<files\>…\</files\>语法进行文件添加，其中file
-category的定义如表1-1所示，在name中可以添加文件路径和具体的某个文件，在软件包中，我们添加的文件默认是不可编辑的，为了方便用户对文件进行进行配置，我们需要添加attr="config"属性，并可通过version更新不同版本的文件。
+id"即为上述介绍的`<condition>`标签，从而用户在使用该组件时，还需要满足 condition 所要求的依赖组件。另外，在定义某一个`<component>`时，需要按照上面程序的`<files>`…`</files>`语法进行文件添加，其中 file
+category 的定义如表 1-1 所示，在 name 中可以添加文件路径和具体的某个文件，在软件包中，我们添加的文件默认是不可编辑的，为了方便用户对文件进行进行配置，我们需要添加 attr="config"属性，并可通过 version 更新不同版本的文件。
 
-表1-1 file category定义
+表 1-1 file category 定义
 
 | category | 含义                         |
-|----------|------------------------------|
+| -------- | ---------------------------- |
 | doc      | 文件，可以是网页或者其他链接 |
 | include  | 包含某一个路径下的所有头文件 |
 | header   | 包含某路径下的具体头文件     |
-| source   | .c源文件                     |
+| source   | .c 源文件                    |
 
-为了使我们设计的软件包能够适配不同的内核，即在使用软件包时与用户ARM核不一致的文件都不出现，可以按如下步骤进行\<files\>的添加：（1）在condition条件中，加入\<require
-Dvendor="ARM:82" Dname="ARMCM0"/\>这样的程序，该程序表示需要用户选择ARM
-Cortex-M0内核才会触发该条件；（2）在添加\<files\>时，我们可以将针对不同内核，同一类型文件的Cgroup和Csub保持同样的名字，并添加上（1）中定义的condition，这样用户选择不同内核时，将只会出现与用户内核一致的文件。
+为了使我们设计的软件包能够适配不同的内核，即在使用软件包时与用户 ARM 核不一致的文件都不出现，可以按如下步骤进行`<files>`的添加：（1）在 condition 条件中，加入`<require Dvendor="ARM:82" Dname="ARMCM0"/>`这样的程序，该程序表示需要用户选择 ARM
+Cortex-M0 内核才会触发该条件；（2）在添加`<files>`时，我们可以将针对不同内核，同一类型文件的 Cgroup 和 Csub 保持同样的名字，并添加上（1）中定义的 condition，这样用户选择不同内核时，将只会出现与用户内核一致的文件。
 
-同时，如果需要在PDSC文件中定义多个软件包，可以采用下列代码结构，其中每一个\<bundle\>标签定义了一个软件包。
+同时，如果需要在 PDSC 文件中定义多个软件包，可以采用下列代码结构，其中每一个`<bundle>`标签定义了一个软件包。
 
-\<components\>
+```xml
+<components>
+	<bundle Cbundle="MDK-ARM" Cclass="TencentOS tiny" Cversion="1.0.0">
+		<description>TencentOS tiny</description>
+		<doc>examples/index.html</doc> 
+		<!-- 添加网页功能-->
+        <component>
+		<!-- 组件内容 -->
+	</component>
+</bundle>
+<bundle Cbundle="MDK-ARM" Cclass="TencentOS tiny" Cversion="1.0.0">
+	<description>TencentOS tiny</description>
+	<doc>examples/index.html</doc>
+	<component>
+		<!-- 组件内容 -->
+	</component>
+</bundle>undefined</components>
+```
 
-\<bundle Cbundle="MDK-ARM" Cclass="TencentOS tiny" Cversion="1.0.0"\>
+另外，PDSC 文件还可以包含`<devices>`、`<apis>`、`<boards>`和`<examples>`，这些为 ARM 公司或者其他器件、开发板厂商提供，为针对器件、api 库文件、板级和相应的示例文件，具体可以参阅 ARM
+CMSIS 的软件包。
 
-\<description\>TencentOS tiny\</description\>
-
-\<doc\>examples/index.html\</doc\> \<!—添加网页功能 --\>
-
-\<component
-
-\<!-- 组件内容 --\>
-
-\</component\>
-
-\</bundle\>
-
-\<bundle Cbundle="MDK-ARM" Cclass="TencentOS tiny" Cversion="1.0.0"\>
-
-\<description\>TencentOS tiny\</description\>
-
-\<doc\>examples/index.html\</doc\>
-
-\<component
-
-\<!-- 组件内容 --\>
-
-\</component\>
-
-\</bundle\>
-
-\</components\>
-
-另外，PDSC文件还可以包含\<devices\>、\<apis\>、\<boards\>和\<examples\>，这些为ARM公司或者其他器件、开发板厂商提供，为针对器件、api库文件、板级和相应的示例文件，具体可以参阅ARM
-CMSIS的软件包。
-
-最后，PDSC文件后还需要在最后加上\</package\>，表示该文件的结束，从而完成PDSC文件的编写。
+最后，PDSC 文件后还需要在最后加上`</package>`，表示该文件的结束，从而完成 PDSC 文件的编写。
 
 ### 1.2.3 生成软件包
 
-在完成PDSC文件的编写后，为了生成最终的软件包，还需要准备如图1.5所示的3个文件，其中PackChk.exe用于验证软件包包含的文件是否都存在，即是否完整；gen_pack.bat为Windows批处理文件，需要我们对文件中的路径进行修改，并用于生成软件包；PACK.xsd是schema，主要用来制定XML规范，用以验证我们编写的PDSC文件。另外，还需要准备7-Zip
-File Manager软件，用于对文件进行压缩，制作集成的软件包。
+在完成 PDSC 文件的编写后，为了生成最终的软件包，还需要准备如图 1.5 所示的 3 个文件，其中 PackChk.exe 用于验证软件包包含的文件是否都存在，即是否完整；gen_pack.bat 为 Windows 批处理文件，需要我们对文件中的路径进行修改，并用于生成软件包；PACK.xsd 是 schema，主要用来制定 XML 规范，用以验证我们编写的 PDSC 文件。另外，还需要准备 7-Zip
+File Manager 软件，用于对文件进行压缩，制作集成的软件包。
 
 ![](media/fb7fd672372ec80d8f841631a36dbb3f.png)
 
@@ -347,13 +300,14 @@ File Manager软件，用于对文件进行压缩，制作集成的软件包。
 
 ![](media/41836625eb0ccd3daf48cabd4ea2b5a1.png)
 
-图1.5 生成软件包所需的软件配置
+图 1.5 生成软件包所需的软件配置
 
-首先利用记事本或Notepad++打开gen_pack.bat，对以下几个地方需要修改，如表1-2所示：
+首先利用记事本或 Notepad++打开 gen_pack.bat，对以下几个地方需要修改，如表 1-2 所示：
 
-SET ZIPPATH=C:\\Program Files\\7-Zip
+```bat
+SET ZIPPATH=C:\Program Files\7-Zip
 
-SET RELEASE_PATH=..\\Local_Release
+SET RELEASE_PATH=..\Local_Release
 
 SET PACK_VENDOR=Tencent
 
@@ -362,169 +316,169 @@ SET PACK_NAME=TencentOS-tiny
 SET PACK_FOLDER_LIST=arch osal kernel examples
 
 SET PACK_FILE_LIST=%PACK_VENDOR%.%PACK_NAME%.pdsc README.md LICENSE.txt
+```
 
-表1-2 gen_pack.bat修改内容
+表 1-2 gen_pack.bat 修改内容
 
-| 代码                 | 含义                             |
-|----------------------|----------------------------------|
-| SET ZIPPATH          | 7-Zip File Manager软件的安装路径 |
-| SET RELEASE_PATH     | 生成的软件包路径，为相对路径     |
-| SET PACK_VENDOR      | PDSC文件中的\<vendor\>标签       |
-| SET PACK_NAME        | PDSC文件中的\<name\>标签         |
-| SET PACK_FOLDER_LIST | 软件包包含文件所在路径           |
-| SET PACK_FILE_LIST   | README.md LICENSE.txt所在路径    |
+| 代码                 | 含义                              |
+| -------------------- | --------------------------------- |
+| SET ZIPPATH          | 7-Zip File Manager 软件的安装路径 |
+| SET RELEASE_PATH     | 生成的软件包路径，为相对路径      |
+| SET PACK_VENDOR      | PDSC 文件中的`<vendor>`标签       |
+| SET PACK_NAME        | PDSC 文件中的`<name>`标签         |
+| SET PACK_FOLDER_LIST | 软件包包含文件所在路径            |
+| SET PACK_FILE_LIST   | README.md LICENSE.txt 所在路径    |
 
-修改完毕gen_pack.bat后，便可以制作软件包了，首先利用cmd打开电脑的命令行界面，执行cd命令转到gen_pack.bat所在的路径，然后输入gen_pack.bat点击enter，如图1.6所示，gen_pack.bat会按照顺序压缩文件，然后读取PDSC文件，检查数据完整性和文件依赖是否完整，然后生成软件包，当提示gen_pack.bat
-completed sucessfully后就完成了软件报的创建。
+修改完毕 gen_pack.bat 后，便可以制作软件包了，首先利用 cmd 打开电脑的命令行界面，执行 cd 命令转到 gen_pack.bat 所在的路径，然后输入 gen_pack.bat 点击 enter，如图 1.6 所示，gen_pack.bat 会按照顺序压缩文件，然后读取 PDSC 文件，检查数据完整性和文件依赖是否完整，然后生成软件包，当提示 gen_pack.bat
+completed sucessfully 后就完成了软件报的创建。
 
 ![](media/b7e362eb1bc37bc91eb9d9af5bb6bd37.png)
 
 ![](media/98771c2e311304bce0f8a7710e1a2629.png)
 
-图1.6 软件包生成界面
+图 1.6 软件包生成界面
 
-此时在Local_Release路径下，可以看到生成的软件包。
+此时在 Local_Release 路径下，可以看到生成的软件包。
 
 ![](media/40a428bcdc26b9aaeafdc0b7da33621c.png)
 
-图1.7 软件包
+图 1.7 软件包
 
-# 2、TencentOS-tiny软件包
+# 2、TencentOS-tiny 软件包
 
 腾讯物联网操作系统（TencentOS
 tiny）是腾讯面向物联网领域开发的实时操作系统，具有低功耗，低资源占用，模块化，可裁剪等特性。TencentOS
-tiny提供了最精简的 RTOS 内核，内核组件可裁剪可配置，可灵活移植到多种终端 MCU
-上。而且，基于RTOS内核，提供了 COAP/MQTT/TLS/DTLS
+tiny 提供了最精简的 RTOS 内核，内核组件可裁剪可配置，可灵活移植到多种终端 MCU
+上。而且，基于 RTOS 内核，提供了 COAP/MQTT/TLS/DTLS
 等常用物联网协议栈及组件，方便用户快速接入腾讯云物联网通信 IoT
 Hub。同时，TencentOS tiny
 为物联网终端厂家提供一站式软件解决方案，方便各种物联网设备快速接入腾讯云，可支撑智慧城市、智能水表、智能家居、智能穿戴、车联网等多种行业应用。
 
-因此，为了有效减少开发人员在移植TencentOS
-tiny到ARM内核单片机上的开发时间，本文基于MDK完成了第三方TencentOS Tiny
-pack和软件包的封装，能够使用MDK pack直接生成适合不同MCU的TencentOS Tiny工程。
+因此，为了有效减少开发人员在移植 TencentOS
+tiny 到 ARM 内核单片机上的开发时间，本文基于 MDK 完成了第三方 TencentOS Tiny
+pack 和软件包的封装，能够使用 MDK pack 直接生成适合不同 MCU 的 TencentOS Tiny 工程。
 
 ## 2.1 软件包内容
 
-结合TencentOS tiny的算法架构，本文设计的软件包包括如表2-1所示的内容：
+结合 TencentOS tiny 的算法架构，本文设计的软件包包括如表 2-1 所示的内容：
 
-表2-1 软件包内容
+表 2-1 软件包内容
 
-| 内容     | 功能                                                                                                                          |                                              |
-|----------|-------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
-| arch     | 包括TencentOS-tiny\\arch\\arm下内核为Cortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23、Cortex-M33的arch文件 |                                              |
-| kernel   | 包括TencentOS-tiny\\kernel下的core、hal路径中的文件、tos_config文件                                                           |                                              |
-| cmsis_os | 对应TencentOS-tiny\\osal\\cmsis_os的文件                                                                                      |                                              |
-| example  | helloworld_main                                                                                                               | 用于测试软件包的main文件                     |
-|          | mcu_it.c                                                                                                                      | 移植软件包时需要按照该文件对中断函数进行修改 |
-|          | mcu_platform.h                                                                                                                | 用户可在此文件在添加对应单片机的头文件       |
+| 内容     | 功能                                                                                                                                |                                              |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| arch     | 包括 TencentOS-tiny\\arch\\arm 下内核为 Cortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23、Cortex-M33 的 arch 文件 |                                              |
+| kernel   | 包括 TencentOS-tiny\\kernel 下的 core、hal 路径中的文件、tos_config 文件                                                            |                                              |
+| cmsis_os | 对应 TencentOS-tiny\\osal\\cmsis_os 的文件                                                                                          |                                              |
+| example  | helloworld_main                                                                                                                     | 用于测试软件包的 main 文件                   |
+|          | mcu_it.c                                                                                                                            | 移植软件包时需要按照该文件对中断函数进行修改 |
+|          | mcu_platform.h                                                                                                                      | 用户可在此文件在添加对应单片机的头文件       |
 
 软件包具有以下功能：
 
-（1）软件包针对ARMCortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23和Cortex-M33内核进行了TencentOS
-tiny软件的封装，用户在安装软件包后能够快速将TencentOS tiny相应内核的Keil工程中；
+（1）软件包针对 ARMCortex-M0+、Cortex-M0、Cortex-M3、Cortex-M4、Cortex-M7、Cortex-M23 和 Cortex-M33 内核进行了 TencentOS
+tiny 软件的封装，用户在安装软件包后能够快速将 TencentOS tiny 相应内核的 Keil 工程中；
 
-（2）软件包能够自动适应用户所选的内核，arch文件能够根据内核自动显示，从而方便用户使用；
+（2）软件包能够自动适应用户所选的内核，arch 文件能够根据内核自动显示，从而方便用户使用；
 
-（3）用户在勾选一个组件时，软件包会自动提示还需要勾选其他模块，并可利用界面中的Resolve一键勾选，防止遗漏；
+（3）用户在勾选一个组件时，软件包会自动提示还需要勾选其他模块，并可利用界面中的 Resolve 一键勾选，防止遗漏；
 
-（4）用户可自主修改对应内核的tos_config文件，对TencentOS tiny的功能进行裁剪。
+（4）用户可自主修改对应内核的 tos_config 文件，对 TencentOS tiny 的功能进行裁剪。
 
 ## 2.2 软件包安装
 
-接下来介绍Tencent.TencentOS-tiny软件包的安装，首先双击图1.5中的软件包，然后进入安装界面，如图2.1(a)，点击I
+接下来介绍 Tencent.TencentOS-tiny 软件包的安装，首先双击图 1.5 中的软件包，然后进入安装界面，如图 2.1(a)，点击 I
 agree to all the terms of the preceding License
-Agreement，再点击next进行安装，安装完成界面如图2.1(b)所示；
+Agreement，再点击 next 进行安装，安装完成界面如图 2.1(b)所示；
 
 ![](media/a76212fa3a130d0aa42ed0d5aa3d1a9d.png)
 ![](media/4e0b4c8cff17038a1c0ca9c35a7093bd.png)
 
 (a) (b)
 
-图2.1 安装界面
+图 2.1 安装界面
 
-此时软件包已经安装到Keil 5之中，打开Keil 5软件，并点击Pack
-Installer图标，可以进行不同软件包版本的安装与移除：
+此时软件包已经安装到 Keil 5 之中，打开 Keil 5 软件，并点击 Pack
+Installer 图标，可以进行不同软件包版本的安装与移除：
 
 ![](media/b88ceffb6b7e01b67048bc376df85b94.png)
 
-图2.2 Pack Installer界面
+图 2.2 Pack Installer 界面
 
-接下来就可以安装Tencent.TencentOS-tiny软件包中的组件，点击Manage Run-Time
-Environment图标，对需要从软件包中移植的文件进行勾选，如图2.3所示，如果有依赖可以点击Resolve进行一键安装。
+接下来就可以安装 Tencent.TencentOS-tiny 软件包中的组件，点击 Manage Run-Time
+Environment 图标，对需要从软件包中移植的文件进行勾选，如图 2.3 所示，如果有依赖可以点击 Resolve 进行一键安装。
 
 ![](media/da8c2b1d2bbe5a9155ac6f1044c9086c.png)
 
-图2.3 Manage Run-Time Environment界面
+图 2.3 Manage Run-Time Environment 界面
 
 # 3、软件包测试
 
-## 3.1 ARM内核移植TencentOS tiny软件包
+## 3.1 ARM 内核移植 TencentOS tiny 软件包
 
 首先在[MDK5 Software Packs
-(keil.com)](https://www.keil.com/dd2/pack/#!#eula-container)下载安装ARM
-CMSIS-5.7.0软件包，以便在不同内核下测试本软件包。
+(keil.com)](https://www.keil.com/dd2/pack/#!#eula-container)下载安装 ARM
+CMSIS-5.7.0 软件包，以便在不同内核下测试本软件包。
 
 ![](media/66abeba588010af544fa689a4d5687fc.png)
 
-图3.1 ARM CMSIS-5.7.0软件包
+图 3.1 ARM CMSIS-5.7.0 软件包
 
-在安装完软件包后，以ARM
-Cortex-M3内核为例对软件包进行移植，并进行编译，首先利用Keil5-5.30版本软件新建工程，并选择ARMCM3，如图3.2所示，然后按照图3.3勾选相应的TencentOS-tiny组件和Cortex-M3内核文件，可以看到arch和tos_config都已经根据内核进行了自动适配。
+在安装完软件包后，以 ARM
+Cortex-M3 内核为例对软件包进行移植，并进行编译，首先利用 Keil5-5.30 版本软件新建工程，并选择 ARMCM3，如图 3.2 所示，然后按照图 3.3 勾选相应的 TencentOS-tiny 组件和 Cortex-M3 内核文件，可以看到 arch 和 tos_config 都已经根据内核进行了自动适配。
 
 ![](media/a644695d0639cedad43437d0daf55c84.png)
 
-图3.2勾选内核
+图 3.2 勾选内核
 
 ![](media/37ddbba2c87e25f8e8c75d19b63eb9bf.png)
 
-图3.3勾选组件
+图 3.3 勾选组件
 
-接下来点击Options for target，选中默认编译版本5，然后选择C99 mode。
+接下来点击 Options for target，选中默认编译版本 5，然后选择 C99 mode。
 
 ![](media/1873eb5d1431042f0de2ffed6bff6c04.png)
 
 ![](media/d486810db3aa3845008f5a9a423c77ef.png)
 
-图3.4 Options for target
+图 3.4 Options for target
 
-然后在mcu_platform.h中添加\#include "ARMCM3.h"和\#include "core_cm3.h"头文件。
+然后在 mcu_platform.h 中添加`#include "ARMCM3.h"`和`#include "core_cm3.h"`头文件。
 
 ![](media/9a97ba66dcac835f6df16d47370855df.png)
 
-图3.5 添加对应内核的头文件
+图 3.5 添加对应内核的头文件
 
-最后点击Build图标进行测试，如图3.6所示：
+最后点击 Build 图标进行测试，如图 3.6 所示：
 
 ![](media/589898df2b1bef2552e3d8ae3af98251.png)
 
-图3.6 编译测试
+图 3.6 编译测试
 
-与之类似，如果要在ARM
-Cortex-M4内核下对本软件包进行测试，只需要在上述步骤修改mcu_platform.h中的头文件为\#include
-"ARMCM4.h"和\#include "core_cm4.h"即可，如果是其他内核则对应修改头文件。
+与之类似，如果要在 ARM
+Cortex-M4 内核下对本软件包进行测试，只需要在上述步骤修改 mcu_platform.h 中的头文件为`#include "ARMCM4.h"`和`#include "core_cm4.h"`即可，如果是其他内核则对应修改头文件。
 
-## 3.2 STM32不依赖裸机工程移植
+## 3.2 STM32 不依赖裸机工程移植
 
 接下来选取具体单片机芯片，进行软件包的测试，按照以下步骤：
 
-在网站MDK5 Software Packs
-(keil.com)上下载STM32F1的软件支持包，如图3.7所示，并进行安装。
+在网站 MDK5 Software Packs
+(keil.com)上下载 STM32F1 的软件支持包，如图 3.7 所示，并进行安装。
 
 ![](media/d8af8e2edc40cc8ba9118bd25e011cd5.png)
 
-图3.7 STM32软件支持包
+图 3.7 STM32 软件支持包
 
-新建工程，选择芯片为STM32F103C8，如图3.8所示，然后点击ok，按照图3.9所示，选择TencentOS-tiny软件包的组件和STM32的启动文件。
+新建工程，选择芯片为 STM32F103C8，如图 3.8 所示，然后点击 ok，按照图 3.9 所示，选择 TencentOS-tiny 软件包的组件和 STM32 的启动文件。
 
 ![](media/0a73b53d3e30e784f48a79fd32c84e66.png)
 
-图3.8 选择STM32F103C8芯片
+图 3.8 选择 STM32F103C8 芯片
 
 ![](media/2a43a3b2017e1d0da8b3384f7933f2d4.png)
 
-图3.9 选择组件
+图 3.9 选择组件
 
-然后按照图3.10(a)所示勾选编译版本5，并选择C99mode。
+然后按照图 3.10(a)所示勾选编译版本 5，并选择 C99mode。
 
 ![](media/1873eb5d1431042f0de2ffed6bff6c04.png)
 
@@ -534,61 +488,64 @@ Cortex-M4内核下对本软件包进行测试，只需要在上述步骤修改mc
 
 (b)
 
-图3.10 软件设置
+图 3.10 软件设置
 
-然后按照图3.11，在mcu_platform.h中添加以下头文件：
+然后按照图 3.11，在 mcu_platform.h 中添加以下头文件：
 
-\#include "stm32f10x.h"
+```c
+#include "stm32f10x.h"
 
-\#include "core_cm3.h"
+#include "core_cm3.h"
 
-\#include "system_stm32f10x.h"
+#include "system_stm32f10x.h"
+```
 
 ![](media/041b53f475d4f82efcec712bf5eb70dc.png)
 
-图3.11 修改mcu_platform.h
+图 3.11 修改 mcu_platform.h
 
-最后点击Build编译，没有报错则移植成功。
+最后点击 Build 编译，没有报错则移植成功。
 
 ![](media/aee29502a5a59eedcc261bd130d55ef7.png)
 
-图3.12 编译界面
+图 3.12 编译界面
 
 ## 3.3 单片机裸机工程移植
 
-最后对单片机开发板进行测试，以正点原子探索者STM32F407ZGT6为例介绍TencentOS-tiny软件包的移植。
+最后对单片机开发板进行测试，以正点原子探索者 STM32F407ZGT6 为例介绍 TencentOS-tiny 软件包的移植。
 
 （1）如下图为软件包勾选的内容：
 
 ![](media/244e3aef94e671a066e2d4b9c934c9d2.png)
 
-图3.13 软件包组件勾选
+图 3.13 软件包组件勾选
 
-在正点原子探索者STM32F407ZGT6裸机工程模板中移植软件包后的界面如图3.14所示：
+在正点原子探索者 STM32F407ZGT6 裸机工程模板中移植软件包后的界面如图 3.14 所示：
 
 ![](media/7d039ebb51d2ee8d49bad77cb14cb7a7.png)
 
-图3.14 移植界面
+图 3.14 移植界面
 
-（2）然后按照mcu_it.c对stm32f4xx_it.c中的PendSV_Handler()函数和SysTick_Handler()函数进行修改，如下图所示，注释stm32f4xx_it.c中的PendSV_Handler()函数，并修改SysTick_Handler()函数。
+（2）然后按照 mcu_it.c 对 stm32f4xx_it.c 中的 PendSV_Handler()函数和 SysTick_Handler()函数进行修改，如下图所示，注释 stm32f4xx_it.c 中的 PendSV_Handler()函数，并修改 SysTick_Handler()函数。
 
 ![](media/96b988085bb718244b84cd800467728f.png)
 
-图3.15 函数修改
+图 3.15 函数修改
 
-（3）对mcu_platform.h进行修改，添加\#include "stm32f4xx.h"
+（3）对 mcu_platform.h 进行修改，添加`#include "stm32f4xx.h"`
 
 ![](media/9ab294a1beab98c5f618a2799326ae73.png)
 
-图3.16 修改mcu_platform.h
+图 3.16 修改 mcu_platform.h
 
-（4）接下来，使用如下main程序：
+（4）接下来，使用如下 main 程序：
 
-\#include "stm32f4xx.h"
+```c
+#include "stm32f4xx.h"
 
-\#include "usart.h"
+#include "usart.h"
 
-\#include "tos_k.h"
+#include "tos_k.h"
 
 k_task_t task1;
 
@@ -598,131 +555,107 @@ k_stack_t task_stack1[1024];
 
 k_stack_t task_stack2[1024];
 
-void test_task1(void \*Parameter)
-
+void test_task1(void *Parameter)
 {
-
-while(1)
-
-{
-
-printf("task1 running\\r\\n");
-
-tos_task_delay(200);
-
+    while (1)
+    {
+        printf("task1 running\r\n");
+        tos_task_delay(200);
+    }
 }
 
-}
-
-void test_task2(void \*Parameter)
-
+void test_task2(void *Parameter)
 {
+    k_err_t err;
 
-k_err_t err;
+    printf("task2 running\r\n");
 
-printf("task2 running\\r\\n");
+    tos_task_delay(2000);
 
-tos_task_delay(2000);
+    // suspend task1暂停
+    printf("suspend task1\r\n");
 
-// suspend task1暂停
+    err = tos_task_suspend(&task1);
 
-printf("suspend task1\\r\\n");
+    if (err != K_ERR_NONE)
+        printf("suspend task1 fail! code : %d \r\n", err);
 
-err = tos_task_suspend(&task1);
+    tos_task_delay(2000);
 
-if(err != K_ERR_NONE)
+    // resume task1恢复
+    printf("resume task1\r\n");
 
-printf("suspend task1 fail! code : %d \\r\\n",err);
+    err = tos_task_resume(&task1);
 
-tos_task_delay(2000);
+    if (err != K_ERR_NONE)
 
-// resume task1恢复
+    printf("resume task1 fail! code : %d \r\n", err);
 
-printf("resume task1\\r\\n");
+    tos_task_delay(2000);
 
-err = tos_task_resume(&task1);
+    // destroy task1销毁
+    printf("destroy task1\r\n");
 
-if(err != K_ERR_NONE)
+    err = tos_task_destroy(&task1);
 
-printf("resume task1 fail! code : %d \\r\\n",err);
+    if (err != K_ERR_NONE)
 
-tos_task_delay(2000);
+    printf("destroy task1 fail! code : %d \r\n", err);
 
-// destroy task1销毁
+    // task2 running
+    while (1)
+    {
+        printf("task2 running\r\n");
 
-printf("destroy task1\\r\\n");
-
-err = tos_task_destroy(&task1);
-
-if(err != K_ERR_NONE)
-
-printf("destroy task1 fail! code : %d \\r\\n",err);
-
-// task2 running
-
-while(1)
-
-{
-
-printf("task2 running\\r\\n");
-
-tos_task_delay(1000);
-
-}
-
+        tos_task_delay(1000);
+    }
 }
 
 int main(void)
-
 {
+    k_err_t err;
 
-k_err_t err;
+    /*初始化USART 配置模式为 115200 8-N-1，中断接收*/
+    uart_init(115200);
 
-/\*初始化USART 配置模式为 115200 8-N-1，中断接收\*/
+    printf("Welcome to TencentOS tiny\r\n");
 
-uart_init(115200);
+    tos_knl_init(); // TOS Tiny kernel initialize
 
-printf("Welcome to TencentOS tiny\\r\\n");
+    tos_robin_default_timeslice_config((k_timeslice_t)500u);
 
-tos_knl_init(); // TOS Tiny kernel initialize
+    printf("create task1\r\n");
 
-tos_robin_default_timeslice_config((k_timeslice_t)500u);
+    err = tos_task_create(&task1, "task1", test_task1, NULL, 3, task_stack1, 1024, 20);
 
-printf("create task1\\r\\n");
+    if (err != K_ERR_NONE)
 
-err = tos_task_create(&task1, "task1", test_task1, NULL, 3, task_stack1, 1024,
-20);
+    printf("TencentOS Create task1 fail! code : %d \r\n", err);
 
-if(err != K_ERR_NONE)
+    printf("create task2\r\n");
 
-printf("TencentOS Create task1 fail! code : %d \\r\\n",err);
+    err = tos_task_create(&task2, "task2", test_task2, NULL, 4, task_stack2, 1024, 20);
 
-printf("create task2\\r\\n");
+    if (err != K_ERR_NONE)
 
-err = tos_task_create(&task2, "task2", test_task2, NULL, 4, task_stack2, 1024,
-20);
+    printf("TencentOS Create task2 fail! code : %d \r\n", err);
 
-if(err != K_ERR_NONE)
-
-printf("TencentOS Create task2 fail! code : %d \\r\\n",err);
-
-tos_knl_start(); // Start TOS Tiny
-
+    tos_knl_start(); // Start TOS Tiny
 }
+```
 
-（5）点击编译，并利用ST
-LINK-V2将程序下载到单片机上，如图3.17，然后将单片机的串口与电脑连接起来，利用XCOM串口通讯助手进行查看，结果如图3.18所示。
+（5）点击编译，并利用 ST
+LINK-V2 将程序下载到单片机上，如图 3.17，然后将单片机的串口与电脑连接起来，利用 XCOM 串口通讯助手进行查看，结果如图 3.18 所示。
 
 ![](media/eabe7550f7c093aab25191d5e2d2e574.png)
 
-图3.17 编译界面
+图 3.17 编译界面
 
 ![](media/6ae58199b9fc760d8a73b48cec67924d.png)
 
-图3.18 测试界面
+图 3.18 测试界面
 
-另外，在编译过程中如果遇到图3.19(a)的报错，需要将图3.19(b)中的\#define
-TOS_CFG_OBJECT_VERIFY_EN 1u修改为TOS_CFG_OBJECT_VERIFY_EN 0u
+另外，在编译过程中如果遇到图 3.19(a)的报错，需要将图 3.19(b)中的`#define TOS_CFG_OBJECT_VERIFY_EN 1u`修改为`TOS_CFG_OBJECT_VERIFY_EN 0u`
 
 ![](media/098dcc332ed6d345bba001e757104353.png)
 
@@ -732,176 +665,194 @@ TOS_CFG_OBJECT_VERIFY_EN 1u修改为TOS_CFG_OBJECT_VERIFY_EN 0u
 
 (b)
 
-图3.19 报错修改
+图 3.19 报错修改
 
 # 4、总结
 
-本文首先研究了基于MDK完成第三方软件包封装的开发过程，并编写了软件包制作的步骤，然后结合TencentOS
-Tiny物联网操作系统，对其中的ARM内核架构下的文件进行了封装，从而设计了基于TencentOS
-Tiny的软件包。
+本文首先研究了基于 MDK 完成第三方软件包封装的开发过程，并编写了软件包制作的步骤，然后结合 TencentOS
+Tiny 物联网操作系统，对其中的 ARM 内核架构下的文件进行了封装，从而设计了基于 TencentOS
+Tiny 的软件包。
 
-本软件包能够方便开发者快速地将TencentOS
-Tiny操作系统移植到用户的ARM内核单片机上，大大节省了开发移植的时间，同时软件包具有自动适配内核和依赖提示的功能，能够提高移植的效率。
+本软件包能够方便开发者快速地将 TencentOS
+Tiny 操作系统移植到用户的 ARM 内核单片机上，大大节省了开发移植的时间，同时软件包具有自动适配内核和依赖提示的功能，能够提高移植的效率。
 
 # 5、开发参考
 
 1、腾讯物联网操作系统网址<https://github.com/OpenAtomFoundation/TencentOS-tiny>
 
-2、MDK5软件包MDK5 Software Packs (keil.com)
+2、MDK5 软件包 MDK5 Software Packs (keil.com)
 
-3、制作软件包培训视频https://www.bilibili.com/video/BV1AK411p7d9
+3、制作软件包培训视频<https://www.bilibili.com/video/BV1AK411p7d9>
 
-4、制作软件包博客https://blog.csdn.net/qq_40259429/article/details/119320319
+4、制作软件包博客<https://blog.csdn.net/qq_40259429/article/details/119320319>
 
-5、制作简易软件包https://www.cnblogs.com/libra13179/p/6273415.html
+5、制作简易软件包<https://www.cnblogs.com/libra13179/p/6273415.html>
 
-6、CMSIS-Driver软件包ARM-software/CMSIS-Driver: Repository of microcontroller
+6、CMSIS-Driver 软件包 ARM-software/CMSIS-Driver: Repository of microcontroller
 peripheral driver implementing the CMSIS-Driver API specification (github.com)
 
 # 6、附录-移植配置参考
 
-## 6.1 MDK5.14版本移植到ARM内核
+## 6.1 MDK5.14 版本移植到 ARM 内核
 
-### 6.1.1 Cortex-M0内核移植
+### 6.1.1 Cortex-M0 内核移植
 
-（1）Manage Run-Time Environment勾选如下：
+（1）Manage Run-Time Environment 勾选如下：
 
 ![](media/4bf08b4e2307ff5a64f3fbf99926f19b.png)
 
-（2）在mcu_platform.h中添加：
+（2）在 mcu_platform.h 中添加：
 
-\#include "ARMCM0.h"
+```c
+#include "ARMCM0.h"
 
-\#include "core_cm0.h"
+#include "core_cm0.h"
+```
 
 ### 6.1.2 Cortex-M0+内核移植
 
-（1）Manage Run-Time Environment勾选如下：
+（1）Manage Run-Time Environment 勾选如下：
 
 ![](media/3a9f68e87997d419e709c656933f3327.png)
 
-（2）在mcu_platform.h中添加：
+（2）在 mcu_platform.h 中添加：
 
-\#include "ARMCM0plus.h"
+```c
+#include "ARMCM0plus.h"
 
-\#include "core_cm0plus.h"
+#include "core_cm0plus.h"
+```
 
-### 6.1.3 Cortex-M3内核移植
+### 6.1.3 Cortex-M3 内核移植
 
-（1）Manage Run-Time Environment勾选如下：
+（1）Manage Run-Time Environment 勾选如下：
 
 ![](media/06581371b251d67e37967e491f2c3b4e.png)
 
-（2）在mcu_platform.h中添加：
+（2）在 mcu_platform.h 中添加：
 
-\#include "ARMCM3.h"
+```c
+#include "ARMCM3.h"
 
-\#include "core_cm3.h"
+#include "core_cm3.h"
+```
 
-### 6.1.4 Cortex-M4内核移植
+### 6.1.4 Cortex-M4 内核移植
 
-（1）Manage Run-Time Environment勾选如下：
+（1）Manage Run-Time Environment 勾选如下：
 
 ![](media/1fb57d5d2e131eefd894c26f9884eb64.png)
 
-（2）在mcu_platform.h中添加：
+（2）在 mcu_platform.h 中添加：
 
-\#include "ARMCM4.h"
+```c
+#include "ARMCM4.h"
 
-\#include "core_cm4.h"
+#include "core_cm4.h"
+```
 
-### 6.1.5 Cortex-M7内核移植
+### 6.1.5 Cortex-M7 内核移植
 
-1、Manage Run-Time Environment勾选如下：
+1、Manage Run-Time Environment 勾选如下：
 
 ![](media/84734d13be5195307cf288639107f728.png)
 
-2、在MDK中修改为C99
+2、在 MDK 中修改为 C99
 
 ![](media/eaa74687e2374e6863dc32cd337760cb.png)
 
-3、在mcu_platform.h中添加：
+3、在 mcu_platform.h 中添加：
 
-\#include "ARMCM7.h"
+```c
+#include "ARMCM7.h"
 
-\#include "core_cm7.h"
+#include "core_cm7.h"
+```
 
-## 6.2 MDK5.14版本移植到基于ARM内核的芯片
+## 6.2 MDK5.14 版本移植到基于 ARM 内核的芯片
 
-### 6.2.1 移植到stm32f103c8芯片
+### 6.2.1 移植到 stm32f103c8 芯片
 
-1、Manage Run-Time Environment勾选如下：
+1、Manage Run-Time Environment 勾选如下：
 
 ![](media/3b64c5bf797e1779c87c3bf390845f4c.png)
 
-2、在mcu_platform.h中添加：
+2、在 mcu_platform.h 中添加：
 
-\#include "stm32f10x.h"
+```c
+#include "stm32f10x.h"
 
-\#include "core_cm3.h"
+#include "core_cm3.h"
 
-\#include "system_stm32f10x.h"
+#include "system_stm32f10x.h"
+```
 
-### 6.2.2 移植到stm32f767igt芯片
+### 6.2.2 移植到 stm32f767igt 芯片
 
-1、Manage Run-Time Environment勾选如下：
+1、Manage Run-Time Environment 勾选如下：
 
 ![](media/91c2c98ce005e1159ac430772c446a17.png)
 
-2、在MDK中修改为C99
+2、在 MDK 中修改为 C99
 
 ![](media/eaa74687e2374e6863dc32cd337760cb.png)
 
-3、在mcu_platform.h中添加：
+3、在 mcu_platform.h 中添加：
 
-\#include "stm32f7xx.h"
+```c
+#include "stm32f7xx.h"
 
-\#include "core_cm7.h"
+#include "core_cm7.h"
 
-\#include "system_stm32f7xx.h"
+#include "system_stm32f7xx.h"
+```
 
-## 6.3 MDK5.30和MDK5.35版本移植（Cortex-M0+、0、3、4、7内核和芯片）
+## 6.3 MDK5.30 和 MDK5.35 版本移植（Cortex-M0+、0、3、4、7 内核和芯片）
 
-在MDK5.30和MDK5.35版本的Keil移植TencentOS-tiny
-Pack时，对于Cortex-M0+、0、3、4、7的内核和芯片，勾选组件和添加头文件的步骤之前一致，但是需要修改编译器的版本，具体修改如下，然后执行编译即可。
+在 MDK5.30 和 MDK5.35 版本的 Keil 移植 TencentOS-tiny
+Pack 时，对于 Cortex-M0+、0、3、4、7 的内核和芯片，勾选组件和添加头文件的步骤之前一致，但是需要修改编译器的版本，具体修改如下，然后执行编译即可。
 
 ![](media/241f9986adb8bd76f2c9836e98fe53e0.png)
 
 ![](media/f0e11c195cd20abdca5fd5a9dc85ac7c.png)
 
-## 6.4 MDK5.30和MDK5.35版本移植（Cortex-M23、33）
+## 6.4 MDK5.30 和 MDK5.35 版本移植（Cortex-M23、33）
 
-### 6.4.1 Cortex-M23内核移植
+### 6.4.1 Cortex-M23 内核移植
 
-（1）Manage Run-Time Environment勾选如下：
+（1）Manage Run-Time Environment 勾选如下：
 
 ![](media/b023beba923e4ae086a2091df55e270e.png)
 
-（2）在mcu_platform.h中添加：
+（2）在 mcu_platform.h 中添加：
 
-\#include "ARMCM23.h"
+```c
+#include "ARMCM23.h"
 
-\#include "core_cm23.h"
+#include "core_cm23.h"
+```
 
 （3）修改为不查看报错：
 
 ![](media/3b90a1c32386f1e405dfa5f52a9b6a07.png)
 
-### 6.4.2 Cortex-M33内核移植
+### 6.4.2 Cortex-M33 内核移植
 
-（1）选择带FPU的芯片
+（1）选择带 FPU 的芯片
 
 ![](media/6746e7af0809a3073a7ea466d9e71771.png)
 
-（2）Manage Run-Time Environment勾选如下：
+（2）Manage Run-Time Environment 勾选如下：
 
 ![](media/5572ec30b5150aedb841b892b751140c.png)
 
-（3）在mcu_platform.h中添加：
+（3）在 mcu_platform.h 中添加：
 
-\#include "ARMCM33_DSP_FP.h"
+```c
+#include "ARMCM33_DSP_FP.h"
 
-\#include "core_cm33.h"
+#include "core_cm33.h"
+```
 
 （4）修改为不查看报错：
 

--- a/tools/mdk_pack/Documentation/README_EN.md
+++ b/tools/mdk_pack/Documentation/README_EN.md
@@ -157,24 +157,19 @@ tag contains the protocol that the user needs to follow to use the pack; the \<
 support \> tag contains a description of the pack. Figure 1.2 shows the pack
 interface for the following code.
 
-\<? xml version="1.0" encoding="utf-8"? \>
-
-\<pack schemaVersion="1.0"
-xmlns:[xs=http://www.w3.org/2001/XMLSchema-instance](http://www.w3.org/2001/XMLSchema-instance)
-xs:noNamespaceSchemaLocation="PACK.xsd"\>
-
-\<name\> Tencent\</name\>
-
-\< description \> Description of your pack\</description
-
-\<vendor\> TencentOS-tiny\</vendor\>
-
-\< url\>
-[https://github.com/OpenAtomFoundation/TencentOS-tiny](https://github.com/OpenAtomFoundation/TencentOS-tiny)\</url\>
-
-\<license\>LICENSE.txt\</license\>
-
-\< supportContact\> ...\</supportContact\>
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package schemaVersion="1.0"
+	xmlns:xs=
+	<http://www.w3.org/2001/XMLSchema-instance>
+xs:noNamespaceSchemaLocation="PACK.xsd">
+		<name>Tencent</name>
+		<description>Description of your pack</description>
+		<vendor>TencentOS-tiny</vendor>
+		<url>[https://github.com/OpenAtomFoundation/TencentOS-tiny](https://github.com/OpenAtomFoundation/TencentOS-tiny)</url>
+		<license>LICENSE.txt</license>
+		<supportContact>…</supportContact>
+```
 
 ![](media_en/0809f249e08db80cbdb8062f75c5eb14.png)
 
@@ -185,17 +180,20 @@ of the pack, where the developer can mark when the version is updated, so that
 when the pack is generated, the system will automatically generate the latest
 version of the pack.
 
-\<releases\>
+```xml
+<releases>
+	<release version=**"1.0.1"**>
 
-\<release version=**"1.0.1**"\> Sep/3/2021, version name
+Sep/3/2021, version name
 
-\</release\>
+</release>
+	<release version=**"1.0.0"**>
 
-\<release version=**"1.0.0**"\> Sep/1/2021, version name
+Sep/1/2021, version name
 
-\</release\>
-
-\</releases\>
+</release>
+</releases>
+```
 
 The \< taxonomy\> tag is used to define the description for each component, as
 shown in Figure 1.3, by identifying where the description is located with the
@@ -203,12 +201,12 @@ following code for Cclass, Cgroup and Csub, doc is used to specify the
 description file (which may or may not be added) and then adding the name of the
 description.
 
-\<taxonomy\>
-
-\<description Cclass="TencentOS tiny" Cgroup="xx" Csub="xx" doc =
-"examples/index.html"\> TencentOS tiny\</description\>
-
-\</taxonomy\>
+```xml
+<taxonomy>
+	<description Cclass="TencentOS tiny" Cgroup="xx" Csub="xx"
+doc="examples/index.html">TencentOS tiny</description>
+</taxonomy>
+```
 
 ![](media_en/f82ec656ef23d89a3442d5e6fffaa271.png)
 
@@ -217,11 +215,11 @@ Figure 1.3 \< taxonomy\> tag
 The \< keywords \> tag defines the keywords for the pack, which can be used to
 search for the pack you need when downloading packs from the ARM website.
 
-\<keywords \>
-
-\<keyword\>Tencent\</keyword\>
-
-\</keywords \>
+```xml
+<keywords>
+	<keyword>Tencent</keyword>
+</keywords>
+```
 
 The \< requirements \> tag defines the associated installation requirements for
 the pack, i.e. when installing this pack, other packs need to be installed
@@ -230,15 +228,13 @@ online (URL: [MDK5 Software](https://www.keil.com/dd2/pack/#!%23eula-container)
 example the following definition requires us to install the CMSIS 5.7.0 pack for
 ARM.
 
-\<requirements\>
-
-\<packs\>
-
-\<pack vendor="ARM" name="CMSIS" version="5.7.0"/\>
-
-\</packs\>
-
-\</requirements
+```xml
+<requirements>
+	<packages>
+		<package vendor="ARM" name="CMSIS" version="5.7.0"/>
+	</packages>
+</requirements>
+```
 
 Next is the \< conditions\> tag, which is used when designing \< components\> to
 indicate the dependencies of each component in the pack, i.e. the use of this
@@ -259,23 +255,21 @@ corresponding to that condition, \<require Cclass=" TencentOS tiny"
 Cgroup="kernel" Csub="core"/\> indicates that the user also needs to select the
 core component.
 
-\<conditions\>
-
-\<condition id="Cortex_M0"\>
-
-\<description\> Cortex-M0\</description\>
-
-\<accept Dvendor="ARM:82" Dname="ARMCM0"/\>
-
-\<require condition="condition id"/\>
-
-\< require Tcompiler="ARMCC"/\>
-
-\<require Cclass="TencentOS tiny" Cgroup="kernel" Csub="core"/\>
-
-\</condition\>
-
-\</conditions\>
+```xml
+<conditions>
+	<condition id="Cortex_M0">
+		<description> Cortex-M0</description>
+		<accept Dvendor="ARM:82" Dname="ARMCM0"/>
+		<require condition="condition id "/>
+		< require Tcompiler="ARMCC"/>
+		<require Cclass="TencentOS tiny" Cgroup="kernel" Csub="core"/>
+	</condition>
+	<condition id=" condition_2 ">
+		<description></description>
+		<!-- 第二个condition的内容 -->
+	</condition>
+</conditions>
+```
 
 Then there is the \< components\> tag, which describes all the files contained
 in the pack. When writing programs under this tag, the files need to be divided
@@ -287,29 +281,20 @@ about the component, as shown in Figure 1.4.
 
 Figure 1.4 \<component\> definition screen
 
-\<components\>
-
-\<component Cvendor="Keil" Cclass="TencentOS tiny" Cgroup="arch" Csub="arch"
-Cversion="1.0.1" condition=" condition id"\>
-
-\<description\> description \</description\>
-
-\<files\>
-
-\<file category="doc" name="Documentation/General/html/driver_I2C.html"/\> --\>
-
-\<file category="include" name="arch/arm/arm-v7m/common/include/"/\>
-
-\<file category="header" name="arch/arm/arm-v7m/cortex-m0+/armcc/port.h"/\>
-
-\<file category="header" name="arch/arm/arm-v7m/cortex-m0+/armcc/port_config.h"
-attr="config" version="1.1.0"/\>
-
-\<file category="source" name="arch/arm/arm-v7m/common/tos_cpu.c"/\>
-
-\</files\>
-
-\</components\>
+```xml
+<components>
+	<component Cvendor="Keil" Cclass="TencentOS tiny" Cgroup="arch" Csub="arch"
+Cversion="1.0.1" condition=" condition id">
+		<description> description </description>
+		<files><file category="doc" name="Documentation/General/html/driver_I2C.html"/>
+			<file category="include" name="arch/arm/arm-v7m/common/include/"/>
+			<file category="header" name="arch/arm/arm-v7m/cortex-m0+/armcc/port.h"/>
+			<file category="header" name="arch/arm/arm-v7m/cortex-m0+/armcc/port_config.h" attr="config" version="1.1.0"/>
+			<file category="source" name="arch/arm/arm-v7m/common/tos_cpu.c"/>
+		</files>
+	</component>
+</components>
+```
 
 condition=" condition id" is the \<condition\> tag introduced above, so that the
 user also needs to satisfy the dependencies required by the condition when using
@@ -324,7 +309,7 @@ version.
 Table 1-1 File category definitions
 
 | category | Meaning                                             |
-|----------|-----------------------------------------------------|
+| -------- | --------------------------------------------------- |
 | doc      | Documents, which can be web pages or other links    |
 | include  | Contains all the headers under a certain path       |
 | header   | Contains specific header files under a certain path |
@@ -366,13 +351,31 @@ structure can be used, where each \< bundle\> tag defines a pack.
 
 \< component
 
-\<! -- Component content --\>
+\<! --  --\>
 
 \</component
 
 \</bundle\>
 
 \</components\>
+
+```xml
+<components>
+	<bundle Cbundle="MDK-ARM" Cclass="TencentOS tiny" Cversion="1.0.0"\>
+		<description>TencentOS tiny</description>
+		<doc>examples/index.html</doc> 
+        <component>
+		<!-- Component content -->
+	</component>
+</bundle>
+<bundle Cbundle="MDK-ARM" Cclass="TencentOS tiny" Cversion="1.0.0">
+	<description>TencentOS tiny</description>
+	<doc>examples/index.html</doc>
+	<component>
+		<!-- Component content -->
+	</component>
+</bundle>undefined</components>
+```
 
 In addition, PDSC files can also contain \<devices\>, \<apis\>, \<boards\> and
 \<examples\>, which are provided by ARM or other device or board manufacturers,
@@ -402,9 +405,10 @@ Figure 1.5 Software configuration required to generate the pack
 First open gen_pack.bat using Notepad or Notepad++ and make the following
 changes to the following areas, as shown in Table 1-2.
 
-SET ZIPPATH=C:\\Program Files\\7-Zip
+```bat
+SET ZIPPATH=C:\Program Files\7-Zip
 
-SET RELEASE_PATH=..\\Local_Release
+SET RELEASE_PATH=..\Local_Release
 
 SET PACK_VENDOR=Tencent
 
@@ -413,11 +417,12 @@ SET PACK_NAME=TencentOS-tiny
 SET PACK_FOLDER_LIST=arch osal kernel examples
 
 SET PACK_FILE_LIST=%PACK_VENDOR%.%PACK_NAME%.pdsc README.md LICENSE.txt
+```
 
 Table 1-2 gen_pack.bat modifications
 
 | Code                 | Meaning                                            |
-|----------------------|----------------------------------------------------|
+| -------------------- | -------------------------------------------------- |
 | SET ZIPPATH          | Installation path for 7-Zip File Manager software  |
 | SET RELEASE_PATH     | The path to the generated pack, as a relative path |
 | SET PACK_VENDOR      | The \<vendor\> tag in the PDSC file                |
@@ -467,32 +472,32 @@ designed in this paper includes the elements shown in Table 2-1.
 
 Table 2-1 Software pack contents
 
-| Contents   | Function                                                                                                                                     |                                                                                          |
-|------------|----------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
-|  arch      | Includes arch files for cores Cortex-M0+, Cortex-M0, Cortex-M3, Cortex-M4, Cortex-M7, Cortex-M23, Cortex-M33 under TencentOS-tiny\\arch\\arm |                                                                                          |
-| kernel     | Including the files in the core, hal path under TencentOS-tiny\\kernel and tos_config file                                                   |                                                                                          |
-| cmsis_os   | Files corresponding to TencentOS-tiny\\osal\\cmsis_os                                                                                        |                                                                                          |
-|    example | helloworld_main                                                                                                                              | The main file for testing the pack                                                       |
-|            | mcu_it.c                                                                                                                                     | The interrupt functions need to be modified according to this file when porting the pack |
-|            | mcu_platform.h                                                                                                                               | The user can add the header file of the corresponding microcontroller to this file       |
+| Contents | Function                                                                                                                                     |                                                                                          |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| arch     | Includes arch files for cores Cortex-M0+, Cortex-M0, Cortex-M3, Cortex-M4, Cortex-M7, Cortex-M23, Cortex-M33 under TencentOS-tiny\\arch\\arm |                                                                                          |
+| kernel   | Including the files in the core, hal path under TencentOS-tiny\\kernel and tos_config file                                                   |                                                                                          |
+| cmsis_os | Files corresponding to TencentOS-tiny\\osal\\cmsis_os                                                                                        |                                                                                          |
+| example  | helloworld_main                                                                                                                              | The main file for testing the pack                                                       |
+|          | mcu_it.c                                                                                                                                     | The interrupt functions need to be modified according to this file when porting the pack |
+|          | mcu_platform.h                                                                                                                               | The user can add the header file of the corresponding microcontroller to this file       |
 
 The software pack has the following features.
 
-1.  The pack packs the TencentOS tiny software for the ARMCortex-M0+, Cortex-M0,
-    Cortex-M3, Cortex-M4, Cortex-M7, Cortex-M23 and Cortex-M33 cores, allowing
-    users to quickly integrate the TencentOS tiny corresponding kernel in a Keil
-    project.
+1. The pack packs the TencentOS tiny software for the ARMCortex-M0+, Cortex-M0,
+   Cortex-M3, Cortex-M4, Cortex-M7, Cortex-M23 and Cortex-M33 cores, allowing
+   users to quickly integrate the TencentOS tiny corresponding kernel in a Keil
+   project.
 
-    1.  The pack can automatically adapt to the kernel selected by the user and
-        the arch file can be displayed automatically according to the kernel,
-        thus facilitating the user's use.
+   1. The pack can automatically adapt to the kernel selected by the user and
+      the arch file can be displayed automatically according to the kernel,
+      thus facilitating the user's use.
 
-        1.  When the user checks a component, the pack will automatically prompt
-            that other modules need to be checked and can be checked with one
-            click using Resolve in the interface to prevent omissions.
+      1. When the user checks a component, the pack will automatically prompt
+         that other modules need to be checked and can be checked with one
+         click using Resolve in the interface to prevent omissions.
 
-        2.  Users can modify the tos_config file of the corresponding kernel on
-            their own to tailor the functions of TencentOS tiny.
+      2. Users can modify the tos_config file of the corresponding kernel on
+         their own to tailor the functions of TencentOS tiny.
 
 ## 2.2 Software pack installation
 
@@ -561,7 +566,7 @@ version 5, then select C99 mode.
 
 Figure 3.4 Options for target
 
-Then add the \#include "ARMCM3.h" and \#include "core_cm3.h" header files to
+Then add the `#include "ARMCM3.h"` and `#include "core_cm3.h"` header files to
 mcu_platform.h.
 
 ![](media_en/07c46384195f99f7f857a8ddd86e2c00.png)
@@ -575,8 +580,7 @@ Finally click on the Build icon to test, as shown in Figure 3.6.
 Figure 3.6 Compilation test
 
 Similarly, to test this pack under the ARM Cortex-M4 core, simply modify the
-header files in mcu_platform. h to \#include "ARMCM4.h" and \#include
-"core_cm4.h" in the above steps, or modify the header files correspondingly for
+header files in mcu_platform. h to `#include "ARMCM4.h"` and `#include "core_cm4.h"` in the above steps, or modify the header files correspondingly for
 other cores.
 
 ## 3.2 STM32-independent bare-metal engineering port
@@ -619,11 +623,13 @@ Figure 3.10 Software settings
 
 Then add the following header file to mcu_platform. h, as shown in Figure 3.11.
 
-\#include "stm32f10x.h"
+```c
+#include "stm32f10x.h"
 
-\#include "core_cm3.h"
+#include "core_cm3.h"
 
-\#include "system_stm32f10x.h"
+#include "system_stm32f10x.h"
+```
 
 ![](media_en/765b3494099251eae39043b3a6aed54c.png)
 
@@ -664,7 +670,7 @@ function.
 
 Figure 3.15 Function modification
 
-(3) Modify mcu_platform.h by adding \#include "stm32f4xx.h"
+(3) Modify mcu_platform.h by adding `#include "stm32f4xx.h"`
 
 ![](media_en/9ab294a1beab98c5f618a2799326ae73.png)
 
@@ -672,11 +678,12 @@ Figure 3.16 Modifying mcu_platform.h
 
 (4) Next, use the following main program.
 
-\#include "stm32f4xx.h"
+```c
+#include "stm32f4xx.h"
 
-\#include "usart.h"
+#include "usart.h"
 
-\#include "tos_k.h"
+#include "tos_k.h"
 
 k_task_t task1;
 
@@ -686,128 +693,94 @@ k_stack_t task_stack1[1024];
 
 k_stack_t task_stack2[1024];
 
-void test_task1(void \*Parameter)
-
+void test_task1(void *Parameter)
 {
-
-while(1)
-
-{
-
-printf("task1 running\\r\\n");
-
-tos_task_delay(200);
-
+    while (1)
+    {
+        printf("task1 running\r\n");
+        tos_task_delay(200);
+    }
 }
 
-}
-
-void test_task2(void \*Parameter)
-
+void test_task2(void *Parameter)
 {
+    k_err_t err;
 
-k_err_t err;
+    printf("task2 running\r\n");
 
-printf("task2 running\\r\\n");
+    tos_task_delay(2000);
 
-tos_task_delay(2000);
+    // suspend task1暂停
+    printf("suspend task1\r\n");
 
-// suspend task1
+    err = tos_task_suspend(&task1);
 
-printf("suspend task1\\r\\n");
+    if (err != K_ERR_NONE)
+        printf("suspend task1 fail! code : %d \r\n", err);
 
-err = tos_task_suspend(&task1);
+    tos_task_delay(2000);
 
-if(err != K_ERR_NONE)
+    // resume task1恢复
+    printf("resume task1\r\n");
 
-printf("suspend task1 fail! code : %d \\r\\n",err);
+    err = tos_task_resume(&task1);
 
-tos_task_delay(2000);
+    if (err != K_ERR_NONE)
 
-// resume task1
+    printf("resume task1 fail! code : %d \r\n", err);
 
-printf("resume task1\\r\\n");
+    tos_task_delay(2000);
 
-err = tos_task_resume(&task1);
+    // destroy task1销毁
+    printf("destroy task1\r\n");
 
-if(err != K_ERR_NONE)
+    err = tos_task_destroy(&task1);
 
-printf("resume task1 fail! code : %d \\r\\n",err);
+    if (err != K_ERR_NONE)
 
-tos_task_delay(2000);
+    printf("destroy task1 fail! code : %d \r\n", err);
 
-// destroy task1
+    // task2 running
+    while (1)
+    {
+        printf("task2 running\r\n");
 
-printf("destroy task1\\r\\n");
-
-err = tos_task_destroy(&task1);
-
-if(err != K_ERR_NONE)
-
-printf("destroy task1 fail! code : %d \\r\\n",err);
-
-// task2 running
-
-while(1)
-
-{
-
-printf("task2 running\\r\\n");
-
-tos_task_delay(1000);
-
+        tos_task_delay(1000);
+    }
 }
-
-}
-
-/\*\*
-
-\* @brief main function
-
-\* @param none
-
-\* @retval none
-
-\*/
 
 int main(void)
-
 {
+    k_err_t err;
 
-k_err_t err;
+    /*初始化USART 配置模式为 115200 8-N-1，中断接收*/
+    uart_init(115200);
 
-/\* Initialize USART configuration mode to 115200 8-N-1, interrupt function
-receive\*/
+    printf("Welcome to TencentOS tiny\r\n");
 
-uart_init(115200);
+    tos_knl_init(); // TOS Tiny kernel initialize
 
-printf("Welcome to TencentOS tiny\\r\\n");
+    tos_robin_default_timeslice_config((k_timeslice_t)500u);
 
-tos_knl_init(); // TOS Tiny kernel initialize
+    printf("create task1\r\n");
 
-tos_robin_default_timeslice_config((k_timeslice_t)500u);
+    err = tos_task_create(&task1, "task1", test_task1, NULL, 3, task_stack1, 1024, 20);
 
-printf("create task1\\r\\n");
+    if (err != K_ERR_NONE)
 
-err = tos_task_create(&task1, "task1", test_task1, NULL, 3, task_stack1, 1024,
-20);
+    printf("TencentOS Create task1 fail! code : %d \r\n", err);
 
-if(err != K_ERR_NONE)
+    printf("create task2\r\n");
 
-printf("TencentOS Create task1 fail! code : %d \\r\\n",err);
+    err = tos_task_create(&task2, "task2", test_task2, NULL, 4, task_stack2, 1024, 20);
 
-printf("create task2\\r\\n");
+    if (err != K_ERR_NONE)
 
-err = tos_task_create(&task2, "task2", test_task2, NULL, 4, task_stack2, 1024,
-20);
+    printf("TencentOS Create task2 fail! code : %d \r\n", err);
 
-if(err != K_ERR_NONE)
-
-printf("TencentOS Create task2 fail! code : %d \\r\\n",err);
-
-tos_knl_start(); // Start TOS Tiny
-
+    tos_knl_start(); // Start TOS Tiny
 }
+```
 
 (5) Then click compile and use ST LINK-V2 to download the program to the
 microcontroller as shown in Figure 3.17. Then connect the serial port of the
@@ -823,8 +796,8 @@ Figure 3.17 Compilation interface
 Figure 3.18 Test interface
 
 In addition, if you encounter the error in Figure 3.19(a) during compilation,
-you need to change \#define TOS_CFG_OBJECT_VERIFY_EN 1u to
-TOS_CFG_OBJECT_VERIFY_EN 0u in Figure 3.19(b)
+you need to change `#define TOS_CFG_OBJECT_VERIFY_EN 1u` to
+`TOS_CFG_OBJECT_VERIFY_EN 0u` in Figure 3.19(b)
 
 ![](media_en/4fa1aaf0199ee8bd345183c950581734.png)
 
@@ -856,18 +829,18 @@ to improve porting efficiency.
 2\. MDK[5 Software Packs MDK5 Software Packs
 (keil.com)](https://www.keil.com/dd2/pack/#!%23eula-container)
 
-1.  Production of software pack training videos
-    <https://www.bilibili.com/video/BV1AK411p7d9>
+1. Production of software pack training videos
+   <https://www.bilibili.com/video/BV1AK411p7d9>
 
-2.  Production pack blog
-    <https://blog.csdn.net/qq_40259429/article/details/119320319>
+2. Production pack blog
+   <https://blog.csdn.net/qq_40259429/article/details/119320319>
 
-3.  Make a simple pack <https://www.cnblogs.com/libra13179/p/6273415.html>
+3. Make a simple pack <https://www.cnblogs.com/libra13179/p/6273415.html>
 
-4.  CMSIS-Driver pack [ARM-software/CMSIS-Driver: Repository of microcontroller
-    peripheral](https://github.com/ARM-software/CMSIS-Driver) [drivers
-    implementing the CMSIS-Driver API specification (
-    github.com)](https://github.com/ARM-software/CMSIS-Driver)
+4. CMSIS-Driver pack [ARM-software/CMSIS-Driver: Repository of microcontroller
+   peripheral](https://github.com/ARM-software/CMSIS-Driver) [drivers
+   implementing the CMSIS-Driver API specification (
+   github.com)](https://github.com/ARM-software/CMSIS-Driver)
 
 # 6、Appendix - Migration Configuration Reference
 
@@ -881,9 +854,11 @@ to improve porting efficiency.
 
 （2）In mcu_platform.h, add：
 
-\#include "ARMCM0.h"
+```c
+#include "ARMCM0.h"
 
-\#include "core_cm0.h"
+#include "core_cm0.h"
+```
 
 ### 6.1.2 Cortex-M0+ core porting
 
@@ -893,9 +868,11 @@ to improve porting efficiency.
 
 （2）In mcu_platform.h, add.
 
-\#include "ARMCM0plus.h"
+```c
+#include "ARMCM0plus.h"
 
-\#include "core_cm0plus.h"
+#include "core_cm0plus.h"
+```
 
 ### 6.1.3 Cortex-M3 core porting
 
@@ -905,9 +882,11 @@ to improve porting efficiency.
 
 （2）In mcu_platform.h, add.
 
-\#include "ARMCM3.h"
+```c
+#include "ARMCM3.h"
 
-\#include "core_cm3.h"
+#include "core_cm3.h"
+```
 
 ### Cortex-M4 core porting
 
@@ -917,9 +896,11 @@ to improve porting efficiency.
 
 （2）In mcu_platform.h, add.
 
-\#include "ARMCM4.h"
+```c
+#include "ARMCM4.h"
 
-\#include "core_cm4.h"
+#include "core_cm4.h"
+```
 
 ### 6.1.5 Cortex-M7 core porting
 
@@ -933,9 +914,11 @@ to improve porting efficiency.
 
 （3）In mcu_platform.h, add.
 
-\#include "ARMCM7.h"
+```c
+#include "ARMCM7.h"
 
-\#include "core_cm7.h"
+#include "core_cm7.h"
+```
 
 ## 6.2 MDK version 5.14 ported to ARM core-based chips
 
@@ -947,11 +930,13 @@ to improve porting efficiency.
 
 （2）In mcu_platform.h, add.
 
-\#include "stm32f10x.h"
+```c
+#include "stm32f10x.h"
 
-\#include "core_cm3.h"
+#include "core_cm3.h"
 
-\#include "system_stm32f10x.h"
+#include "system_stm32f10x.h"
+```
 
 ### Porting to the STM32F767IGTx chip
 
@@ -965,11 +950,13 @@ to improve porting efficiency.
 
 （3）In mcu_platform.h, add.
 
-\#include "stm32f7xx.h"
+```c
+#include "stm32f7xx.h"
 
-\#include "core_cm7.h"
+#include "core_cm7.h"
 
-\#include "system_stm32f7xx.h"
+#include "system_stm32f7xx.h"
+```
 
 ## 6.3 MDK5.30 and MDK5.35 porting (Cortex-M0+, 0, 3, 4, 7 cores and chips)
 
@@ -992,9 +979,11 @@ as follows and then just execute the compilation.
 
 （2）In mcu_platform.h, add.
 
-\#include "ARMCM23.h"
+```c
+#include "ARMCM23.h"
 
-\#include "core_cm23.h"
+#include "core_cm23.h"
+```
 
 （3）Amend to not view error reports.
 
@@ -1012,9 +1001,11 @@ as follows and then just execute the compilation.
 
 （3）In mcu_platform.h, add.
 
-\#include "ARMCM33_DSP_FP.h"
+```c
+#include "ARMCM33_DSP_FP.h"
 
-\#include "core_cm33.h"
+#include "core_cm33.h"
+```
 
 （4）Amend to not view error reports.
 


### PR DESCRIPTION
Format Markdown with Prettier automatically. Manually replace escape characters `\` with Markdown inline and block code syntax and format.